### PR TITLE
sks ta: update size input check on EC verify

### DIFF
--- a/ta/secure_key_services/src/processing_asymm.c
+++ b/ta/secure_key_services/src/processing_asymm.c
@@ -469,23 +469,23 @@ uint32_t step_asymm_operation(struct pkcs11_session *session,
 		TEE_GetOperationInfo(proc->tee_op_handle, &opinfo);
 		uint32_t key_size = (opinfo.keySize + 7) / 8;
 		switch (opinfo.algorithm) {
-		case TEE_ALG_ECDSA_P192:
+		case TEE_ALG_ECDSA_SHA1:
 			if (in_size > 24)
 				in_size = 24;
 			break;
-		case TEE_ALG_ECDSA_P224:
+		case TEE_ALG_ECDSA_SHA224:
 			if (in_size > 28)
 				in_size = 28;
 			break;
-		case TEE_ALG_ECDSA_P256:
+		case TEE_ALG_ECDSA_SHA256:
 			if (in_size > 32)
 				in_size = 32;
 			break;
-		case TEE_ALG_ECDSA_P384:
+		case TEE_ALG_ECDSA_SHA384:
 			if (in_size > 48)
 				in_size = 48;
 			break;
-		case TEE_ALG_ECDSA_P521:
+		case TEE_ALG_ECDSA_SHA512:
 			if (in_size > 64)
 				in_size = 64;
 			break;

--- a/ta/secure_key_services/src/processing_asymm.c
+++ b/ta/secure_key_services/src/processing_asymm.c
@@ -467,6 +467,7 @@ uint32_t step_asymm_operation(struct pkcs11_session *session,
 			goto bail;
 		}
 		TEE_GetOperationInfo(proc->tee_op_handle, &opinfo);
+		uint32_t key_size = (opinfo.keySize + 7) / 8;
 		switch (opinfo.algorithm) {
 		case TEE_ALG_ECDSA_P192:
 			if (in_size > 24)
@@ -494,7 +495,7 @@ uint32_t step_asymm_operation(struct pkcs11_session *session,
 		}
 		/* Validate second input buffer size if verify */
 		if (function == SKS_FUNCTION_VERIFY &&
-				in2_size != 2 * in_size) {
+				in2_size != 2 * key_size) {
 			rv = SKS_CKR_SIGNATURE_LEN_RANGE;
 			goto bail;
 		}

--- a/ta/secure_key_services/src/processing_ec.c
+++ b/ta/secure_key_services/src/processing_ec.c
@@ -1041,19 +1041,11 @@ uint32_t sks2tee_algo_ecdh(uint32_t *tee_id,
 
 	switch (get_object_key_bit_size(obj)) {
 	case 192:
-		*tee_id = TEE_ALG_ECDH_P192;
-		break;
 	case 224:
-		*tee_id = TEE_ALG_ECDH_P224;
-		break;
 	case 256:
-		*tee_id = TEE_ALG_ECDH_P256;
-		break;
 	case 384:
-		*tee_id = TEE_ALG_ECDH_P384;
-		break;
 	case 521:
-		*tee_id = TEE_ALG_ECDH_P521;
+		*tee_id = TEE_ALG_ECDH_DERIVE_SHARED_SECRET;
 		break;
 	default:
 		TEE_Panic(0);
@@ -1112,19 +1104,19 @@ uint32_t sks2tee_algo_ecdsa(uint32_t *tee_id,
 
 	switch (get_object_key_bit_size(obj)) {
 	case 192:
-		*tee_id = TEE_ALG_ECDSA_P192;
+		*tee_id = TEE_ALG_ECDSA_SHA1;
 		break;
 	case 224:
-		*tee_id = TEE_ALG_ECDSA_P224;
+		*tee_id = TEE_ALG_ECDSA_SHA224;
 		break;
 	case 256:
-		*tee_id = TEE_ALG_ECDSA_P256;
+		*tee_id = TEE_ALG_ECDSA_SHA256;
 		break;
 	case 384:
-		*tee_id = TEE_ALG_ECDSA_P384;
+		*tee_id = TEE_ALG_ECDSA_SHA384;
 		break;
 	case 521:
-		*tee_id = TEE_ALG_ECDSA_P521;
+		*tee_id = TEE_ALG_ECDSA_SHA512;
 		break;
 	default:
 		TEE_Panic(0);


### PR DESCRIPTION
Following issue https://github.com/OP-TEE/optee_os/issues/14741

EC verify input check should check signature size against
key size and not against input (hash digest) size.

In many cases it is the same but for example in
P-192/SHA-1 case the key size is 192b and hash size is 160b,
so the sign input is 160b and output signature is 2*192=384b.

In case of P521 public key size can be in range 63-66B.

Signed-off-by: Miroslav Safr <msafr@rambus.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
