### PR TITLE
[FIO internal] caam: workaround CAAM locked by HAB during SDP boot

### DIFF
--- a/core/drivers/crypto/caam/hal/imx_6_7/hal_jr.c
+++ b/core/drivers/crypto/caam/hal/imx_6_7/hal_jr.c
@@ -70,6 +70,12 @@ enum caam_status caam_hal_jr_setowner(vaddr_t ctrl_base, paddr_t jr_offset,
 			if (val == cfg_ls)
 				retstatus = CAAM_NO_ERROR;
 		}
+#ifdef CFG_NXP_WORKAROUND_CAAM_LOCKED_BY_HAB
+		if (retstatus != CAAM_NO_ERROR) {
+			EMSG("HACK: CAAM LOCKED with invalid configuration...continue booting!");
+			retstatus = CAAM_NO_ERROR;
+		}
+#endif
 	} else {
 		HAL_TRACE("JR%" PRIu32 "MIDR_LS set value 0x%" PRIx32, jr_idx,
 			  cfg_ls);


### PR DESCRIPTION
On the imx7ulp and during SDP boot the CAAM is not being unlocked
despite the request being made in the signed image (CSF section).

When this is the case, and if the CAAM is being locked with invalid
MID configs, the CAAM driver would fail to initialize as the MID
registers can not be reconfigured. And this would panic booting the
trust zone.

Ignoring this error and allowing the system to continue booting seems
to fulfill the software upgrade use case requirement (which is where we
use SDP for).

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
