### PR TITLE
[FIO internal] caam: imx7ulp: RPMB workaround for closed boards

### DIFF
--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -14,6 +14,11 @@
  * The default implementation just sets it to a constant.
  */
 
+__weak TEE_Result tee_otp_enable_test_hw_unique_key(void)
+{
+	return TEE_ERROR_SECURITY;
+}
+
 __weak TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	memset(&hwkey->data[0], 0, sizeof(hwkey->data));

--- a/core/arch/arm/plat-imx/drivers/imx_huk.c
+++ b/core/arch/arm/plat-imx/drivers/imx_huk.c
@@ -1,6 +1,7 @@
 #include <drivers/imx_caam_mkvb.h>
 #include <kernel/tee_common_otp.h>
 #include <string.h>
+#include <trace.h>
 
 static uint8_t stored_key[MKVB_SIZE];
 static bool mkvb_retrieved;
@@ -8,18 +9,8 @@ static bool mkvb_retrieved;
 #if defined(CFG_GET_ALTERNATIVE_HUK)
 static bool caam_use_test_hw_key;
 
-#if defined(CFG_MX7ULP)
 /* HUK on open boards (read during tests) */
-static uint8_t hw_test_key[] = {
-	0xc2, 0x0c, 0x77, 0xec, 0xad, 0x89, 0xdc, 0x96,
-	0xb7, 0x9f, 0xc8, 0xf7, 0xda, 0xab, 0x97, 0xb4,
-	0x2a, 0xe8, 0xdf, 0x98, 0x3d, 0x74, 0x1c, 0x34,
-	0xac, 0xa8, 0x63, 0xca, 0xeb, 0x5f, 0xde, 0xcd,
-};
-#else
-#error "please provide alternative huk !"
-static uint8_t hw_test_key[] = { 0 };
-#endif
+static uint8_t hw_test_key[] = { CFG_GET_ALTERNATIVE_HUK };
 
 TEE_Result tee_otp_enable_test_hw_unique_key(void)
 {
@@ -38,6 +29,12 @@ TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 
 #if defined(CFG_GET_ALTERNATIVE_HUK)
 	if (caam_use_test_hw_key) {
+		if (sizeof(hw_test_key) != sizeof(hwkey->data)) {
+			EMSG("invalid CFG_GET_ALTERNATIVE_HUK size (%d, %d)",
+			     sizeof(hw_test_key), sizeof(hwkey->data));
+			return TEE_ERROR_SECURITY;
+		}
+
 		memcpy(&hwkey->data, &hw_test_key, sizeof(hwkey->data));
 
 		/* reset so the real HUK can be used if needed */

--- a/core/arch/arm/plat-imx/drivers/imx_huk.c
+++ b/core/arch/arm/plat-imx/drivers/imx_huk.c
@@ -5,10 +5,46 @@
 static uint8_t stored_key[MKVB_SIZE];
 static bool mkvb_retrieved;
 
+#if defined(CFG_GET_ALTERNATIVE_HUK)
+static bool caam_use_test_hw_key;
+
+#if defined(CFG_MX7ULP)
+/* HUK on open boards (read during tests) */
+static uint8_t hw_test_key[] = {
+	0xc2, 0x0c, 0x77, 0xec, 0xad, 0x89, 0xdc, 0x96,
+	0xb7, 0x9f, 0xc8, 0xf7, 0xda, 0xab, 0x97, 0xb4,
+	0x2a, 0xe8, 0xdf, 0x98, 0x3d, 0x74, 0x1c, 0x34,
+	0xac, 0xa8, 0x63, 0xca, 0xeb, 0x5f, 0xde, 0xcd,
+};
+#else
+#error "please provide alternative huk !"
+static uint8_t hw_test_key[] = { 0 };
+#endif
+
+TEE_Result tee_otp_enable_test_hw_unique_key(void)
+{
+	if (!caam_use_test_hw_key) {
+		caam_use_test_hw_key = true;
+		return TEE_SUCCESS;
+	}
+
+	return TEE_ERROR_SECURITY;
+}
+#endif
+
 TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	int ret = TEE_ERROR_SECURITY;
 
+#if defined(CFG_GET_ALTERNATIVE_HUK)
+	if (caam_use_test_hw_key) {
+		memcpy(&hwkey->data, &hw_test_key, sizeof(hwkey->data));
+
+		/* reset so the real HUK can be used if needed */
+		caam_use_test_hw_key = false;
+		return TEE_SUCCESS;
+	}
+#endif
 	if (!mkvb_retrieved) {
 		ret = caam_get_mkvb(stored_key);
 		if (ret)

--- a/core/include/kernel/tee_common_otp.h
+++ b/core/include/kernel/tee_common_otp.h
@@ -16,6 +16,7 @@ struct tee_hw_unique_key {
 };
 
 TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);
+TEE_Result tee_otp_enable_test_hw_unique_key(void);
 int tee_otp_get_die_id(uint8_t *buffer, size_t len);
 
 #endif /* TEE_COMMON_OTP_H */


### PR DESCRIPTION
Due to a problem in one of our releases, some imx7ulp boards were able
to access RPMB while still in the open state.

In the open state, CAAM provides a HUK that is different to the one
after the board has been closed.

This means that once the boards were closed, RPMB would not longer be
accessible.

The current commit addresses that situation.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
