### PR TITLE
[FIO toup] libnxpse050: core: huk

### DIFF
--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -25,6 +25,7 @@ __weak TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 	return TEE_SUCCESS;
 }
 
+#if !defined(CFG_NXP_SE05X_HUK_DRV)
 __weak int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 {
 	if (huk_subkey_derive(HUK_SUBKEY_DIE_ID, NULL, 0, buffer, len))
@@ -32,3 +33,4 @@ __weak int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 
 	return 0;
 }
+#endif

--- a/core/core.mk
+++ b/core/core.mk
@@ -98,6 +98,7 @@ $(call force, CFG_CRYPTO_RSASSA_NA1, n, not supported by se050)
 $(call force, CFG_NXP_SE05X_SVC, y)
 $(call force, CFG_NXP_SE05X_HMAC_DRV, y)
 $(call force, CFG_NXP_SE05X_RNG_DRV, y)
+$(call force, CFG_NXP_SE05X_HUK_DRV, y)
 libname = nxpse050
 libdir = lib/libnxpse050
 include mk/lib.mk

--- a/lib/libnxpse050/core/huk.c
+++ b/lib/libnxpse050/core/huk.c
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (C) Foundries Ltd. 2020 - All Rights Reserved
+ * Author: Jorge Ramirez <jorge@foundries.io>
+ */
+
+#include <kernel/tee_common_otp.h>
+#include <se050.h>
+#include <string.h>
+#include <tee/tee_cryp_utl.h>
+#include <util.h>
+
+int tee_otp_get_die_id(uint8_t *buffer, size_t len)
+{
+	uint8_t se050_huk[SE050_MODULE_UNIQUE_ID_LEN];
+	size_t se050_huk_len = sizeof(se050_huk);
+	sss_status_t status = kStatus_SSS_Fail;
+
+	memset(buffer, 0, len);
+
+	status = sss_se05x_session_prop_get_au8(se050_session,
+						kSSS_SessionProp_UID,
+						se050_huk, &se050_huk_len);
+	if (status != kStatus_SSS_Success)
+		return -1;
+
+	memcpy(buffer, se050_huk, MIN(len, se050_huk_len));
+
+	return 0;
+}


### PR DESCRIPTION
Report the SE050 unique die id (different than the HUK which in the
case of the IMX platform is being provided by the CAAM).

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
