### PR TITLE
libnxpse050: ECC shared secret, SCP03 rotation, ECC sign/verify fixes

### DIFF
--- a/core/lib/libtomcrypt/ecc.c
+++ b/core/lib/libtomcrypt/ecc.c
@@ -54,7 +54,7 @@ void crypto_acipher_free_ecc_public_key(struct ecc_public_key *s)
 	crypto_bignum_free(s->x);
 	crypto_bignum_free(s->y);
 }
-
+#if !defined(CFG_CORE_SE05X)
 /*
  * curve is part of TEE_ECC_CURVE_NIST_P192,...
  * algo is part of TEE_ALG_ECDSA_P192,..., and 0 if we do not have it
@@ -124,7 +124,7 @@ static TEE_Result ecc_get_keysize(uint32_t curve, uint32_t algo,
 
 	return TEE_SUCCESS;
 }
-#if !defined(CFG_CORE_SE05X)
+
 TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key)
 {
 	TEE_Result res;
@@ -168,7 +168,7 @@ exit:
 	ecc_free(&ltc_tmp_key);		/* Free the temporary key */
 	return res;
 }
-#endif
+
 static TEE_Result ecc_compute_key_idx(ecc_key *ltc_key, size_t keysize)
 {
 	size_t x;
@@ -244,8 +244,6 @@ static TEE_Result ecc_populate_ltc_public_key(ecc_key *ltc_key,
 	return ecc_compute_key_idx(ltc_key, *key_size_bytes);
 }
 
-#if !defined(CFG_CORE_SE05X)
-
 TEE_Result crypto_acipher_ecc_sign(uint32_t algo, struct ecc_keypair *key,
 				   const uint8_t *msg, size_t msg_len,
 				   uint8_t *sig, size_t *sig_len)
@@ -299,7 +297,6 @@ err:
 	return res;
 }
 
-
 TEE_Result crypto_acipher_ecc_verify(uint32_t algo, struct ecc_public_key *key,
 				     const uint8_t *msg, size_t msg_len,
 				     const uint8_t *sig, size_t sig_len)
@@ -341,8 +338,6 @@ out:
 	return res;
 }
 
-#endif
-
 TEE_Result crypto_acipher_ecc_shared_secret(struct ecc_keypair *private_key,
 					    struct ecc_public_key *public_key,
 					    void *secret,
@@ -383,3 +378,4 @@ out:
 	mp_clear_multi(key_z, NULL);
 	return res;
 }
+#endif

--- a/lib/libnxpse050/adaptors/apis/apdu.c
+++ b/lib/libnxpse050/adaptors/apis/apdu.c
@@ -5,6 +5,7 @@
  */
 
 #include <se050_apdu_apis.h>
+#include <string.h>
 
 /*
  * @param pCtx
@@ -689,8 +690,7 @@ sss_status_t se050_key_store_get_ecc_key_bin(sss_se05x_key_store_t *store,
 	case kSSS_CipherType_EC_TWISTED_ED:
 		add_ecc_header(key, &key_buf, &key_buflen, k_object->curve_id);
 		status = Se05x_API_ReadObject(s_ctx, k_object->keyId,
-					      0, 0, key_buf,
-					      key_len);
+					      0, 0, key_buf, key_len);
 		if (status != SM_OK)
 			goto exit;
 
@@ -711,6 +711,42 @@ sss_status_t se050_key_store_get_ecc_key_bin(sss_se05x_key_store_t *store,
 	ret = kStatus_SSS_Success;
 exit:
 	return ret;
+}
+
+/*
+ * @param session
+ * @param id
+ * @param pub_key
+ * @param secret
+ * @param len
+ *
+ * @return sss_status_t
+ */
+sss_status_t se050_ecc_gen_shared_secret(sss_se05x_session_t *session,
+					 uint32_t kid,
+					 struct ecc_public_key_bin *key_pub,
+					 uint8_t *secret, unsigned long *len)
+{
+	uint8_t key[256] = { 0x04 }; /* tag */
+	smStatus_t status = SM_OK;
+	uint8_t *p = key + 1;
+	size_t key_len = 0;
+
+	key_len = key_pub->x_len + key_pub->y_len + 1;
+	if (key_len > sizeof(key)) {
+		EMSG("small buffer");
+		return kStatus_SSS_Fail;
+	}
+
+	memcpy(p, key_pub->x, key_pub->x_len);
+	p += key_pub->x_len;
+	memcpy(p, key_pub->y, key_pub->y_len);
+	status = Se05x_API_ECGenSharedSecret(&session->s_ctx, kid, key, key_len,
+					     secret, len);
+	if (status != SM_OK)
+		return kStatus_SSS_Fail;
+
+	return kStatus_SSS_Success;
 }
 
 /*

--- a/lib/libnxpse050/adaptors/apis/sss.c
+++ b/lib/libnxpse050/adaptors/apis/sss.c
@@ -91,7 +91,7 @@ sss_status_t se050_rotate_scp03_keys(sss_se05x_ctx_t *ctx)
 	if (status != kStatus_SSS_Success)
 		return status;
 
-	status = se050_send_scp03_rotate_cmd(ctx, &cmd);
+	status = se050_send_scp03_rotate_cmd(&session->s_ctx, &cmd);
 	if (status != kStatus_SSS_Success)
 		return status;
 

--- a/lib/libnxpse050/adaptors/apis/sss.c
+++ b/lib/libnxpse050/adaptors/apis/sss.c
@@ -5,6 +5,9 @@
  */
 
 #include <se050.h>
+#include <se050_default_keys.h>
+#include <se050_utils.h>
+#include <string.h>
 
 /*
  * policies
@@ -51,49 +54,123 @@ sss_policy_t se050_asym_policy = {
 };
 
 /*
- * @param pCtx
+ * @param ctx
+ *
+ * @return sss_status_t
+ */
+#if defined(CFG_CORE_SE05X_SCP03_PROVISION) && CFG_CORE_SE05X_SCP03_PROVISION
+sss_status_t se050_rotate_scp03_keys(sss_se05x_ctx_t *ctx)
+{
+	struct se050_scp_key new_keys = {
+		.dek = { CFG_CORE_SE05X_SCP03_NEW_DEK },
+		.mac = { CFG_CORE_SE05X_SCP03_NEW_MAC },
+		.enc = { CFG_CORE_SE05X_SCP03_NEW_ENC },
+	};
+	struct s050_scp_rotate_cmd cmd = { 0 };
+	sss_status_t status = kStatus_SSS_Fail;
+	SE_Connect_Ctx_t *connect_ctx = NULL;
+	sss_se05x_session_t *session = NULL;
+
+	if (!ctx)
+		return kStatus_SSS_Fail;
+
+	connect_ctx = &ctx->open_ctx;
+	session = &ctx->session;
+
+	status = se050_prepare_rotate_cmd(ctx, &cmd, &new_keys);
+	if (status != kStatus_SSS_Success)
+		return status;
+
+	sss_se05x_session_close(session);
+
+	/* unselect the applet so provision can proceed */
+	connect_ctx->skip_select_applet = 1;
+	status = sss_se05x_session_open(session, kType_SSS_SE_SE05x, 0,
+					kSSS_ConnectionType_Encrypted,
+					connect_ctx);
+	if (status != kStatus_SSS_Success)
+		return status;
+
+	status = se050_send_scp03_rotate_cmd(ctx, &cmd);
+	if (status != kStatus_SSS_Success)
+		return status;
+
+	sss_host_session_close(&ctx->host_session);
+
+	return status;
+}
+#else
+sss_status_t se050_rotate_scp03_keys(sss_se05x_ctx_t *ctx)
+{
+}
+#endif
+
+/*
+ * @param ctx
+ * @param encryption
  *
  * @return sss_status_t
  */
 sss_status_t se050_session_open(sss_se05x_ctx_t *ctx, bool encryption)
 {
-	SE_Connect_Ctx_t *pConnectCtx = NULL;
-	sss_se05x_session_t *pSession = NULL;
 	sss_status_t status = kStatus_SSS_Fail;
+	SE_Connect_Ctx_t *connect_ctx = NULL;
+	sss_se05x_session_t *session = NULL;
+#if defined(CFG_CORE_SE05X_OEFID)
+	struct se050_scp_key current_keys = { 0 };
+	uint32_t id = 0;
 
+	if (encryption) {
+		status = se050_get_id_from_ofid(CFG_CORE_SE05X_OEFID, &id);
+		if (status != kStatus_SSS_Success)
+			return kStatus_SSS_Fail;
+
+		IMSG("scp03 current keys defaulting to OEFID");
+		memcpy(&current_keys, &se050_default_keys[id],
+		       sizeof(current_keys));
+	}
+#else
+	struct se050_scp_key current_keys = {
+		.dek = { CFG_CORE_SE05X_SCP03_CURRENT_DEK },
+		.mac = { CFG_CORE_SE05X_SCP03_CURRENT_MAC },
+		.enc = { CFG_CORE_SE05X_SCP03_CURRENT_ENC },
+	};
+#endif
 	if (!ctx)
 		return kStatus_SSS_Fail;
 
-	pConnectCtx = &ctx->open_ctx;
-	pSession = &ctx->session;
+	connect_ctx = &ctx->open_ctx;
+	session = &ctx->session;
 
-	pConnectCtx->connType = kType_SE_Conn_Type_T1oI2C;
-	pConnectCtx->portName = NULL;
+	connect_ctx->connType = kType_SE_Conn_Type_T1oI2C;
+	connect_ctx->portName = NULL;
 
-	if (!encryption)
-		return sss_se05x_session_open(pSession, kType_SSS_SE_SE05x, 0,
+	if (!encryption) {
+		return sss_se05x_session_open(session, kType_SSS_SE_SE05x, 0,
 					      kSSS_ConnectionType_Plain,
-					      pConnectCtx);
+					      connect_ctx);
+	}
 
 	status = se050_configure_host(&ctx->host_session,
 				      &ctx->host_ks,
 				      &ctx->open_ctx,
 				      &ctx->se05x_auth,
-				      kSSS_AuthType_SCP03);
+				      kSSS_AuthType_SCP03,
+				      &current_keys);
 	if (status != kStatus_SSS_Success)
 		return status;
 
-	return sss_se05x_session_open(pSession, kType_SSS_SE_SE05x, 0,
+	return sss_se05x_session_open(session, kType_SSS_SE_SE05x, 0,
 				      kSSS_ConnectionType_Encrypted,
-				      pConnectCtx);
+				      connect_ctx);
 }
 
 /*
- * @param pCtx
+ * @param ctx
  *
  * @return sss_status_t
  */
-sss_status_t se050_kestore_and_object_init(sss_se05x_ctx_t *ctx)
+sss_status_t se050_key_store_and_object_init(sss_se05x_ctx_t *ctx)
 {
 	sss_status_t status = kStatus_SSS_Fail;
 

--- a/lib/libnxpse050/adaptors/include/se050_apdu_apis.h
+++ b/lib/libnxpse050/adaptors/include/se050_apdu_apis.h
@@ -9,6 +9,8 @@
 
 #include <se050.h>
 
+struct s050_scp_rotate_cmd;
+
 sss_status_t se050_factory_reset(sss_se05x_ctx_t *ctx);
 
 sss_status_t se050_cipher_update_nocache(sss_se05x_symmetric_t *ctx,
@@ -89,5 +91,8 @@ sss_status_t se050_ecc_gen_shared_secret(sss_se05x_session_t *session,
 
 sss_status_t se050_get_free_memory(pSe05xSession_t ctx, uint16_t *t,
 				   SE05x_MemoryType_t type);
+
+sss_status_t se050_send_scp03_rotate_cmd(sss_se05x_ctx_t *ctx,
+					 struct s050_scp_rotate_cmd *cmd);
 
 #endif /* SE050_APDU_APIS_H_ */

--- a/lib/libnxpse050/adaptors/include/se050_apdu_apis.h
+++ b/lib/libnxpse050/adaptors/include/se050_apdu_apis.h
@@ -82,6 +82,11 @@ sss_status_t se050_key_store_get_ecc_key_bin(sss_se05x_key_store_t *k_store,
 					     uint8_t *key,
 					     size_t *k_len);
 
+sss_status_t se050_ecc_gen_shared_secret(sss_se05x_session_t *session,
+					 uint32_t id,
+					 struct ecc_public_key_bin *key_pub,
+					 uint8_t *secret, unsigned long *len);
+
 sss_status_t se050_get_free_memory(pSe05xSession_t ctx, uint16_t *t,
 				   SE05x_MemoryType_t type);
 

--- a/lib/libnxpse050/adaptors/include/se050_apdu_apis.h
+++ b/lib/libnxpse050/adaptors/include/se050_apdu_apis.h
@@ -11,7 +11,7 @@
 
 struct s050_scp_rotate_cmd;
 
-sss_status_t se050_factory_reset(sss_se05x_ctx_t *ctx);
+sss_status_t se050_factory_reset(pSe05xSession_t ctx);
 
 sss_status_t se050_cipher_update_nocache(sss_se05x_symmetric_t *ctx,
 					 const uint8_t *src, size_t src_len,
@@ -84,7 +84,7 @@ sss_status_t se050_key_store_get_ecc_key_bin(sss_se05x_key_store_t *k_store,
 					     uint8_t *key,
 					     size_t *k_len);
 
-sss_status_t se050_ecc_gen_shared_secret(sss_se05x_session_t *session,
+sss_status_t se050_ecc_gen_shared_secret(pSe05xSession_t ctx,
 					 uint32_t id,
 					 struct ecc_public_key_bin *key_pub,
 					 uint8_t *secret, unsigned long *len);
@@ -92,7 +92,7 @@ sss_status_t se050_ecc_gen_shared_secret(sss_se05x_session_t *session,
 sss_status_t se050_get_free_memory(pSe05xSession_t ctx, uint16_t *t,
 				   SE05x_MemoryType_t type);
 
-sss_status_t se050_send_scp03_rotate_cmd(sss_se05x_ctx_t *ctx,
+sss_status_t se050_send_scp03_rotate_cmd(pSe05xSession_t ctx,
 					 struct s050_scp_rotate_cmd *cmd);
 
 #endif /* SE050_APDU_APIS_H_ */

--- a/lib/libnxpse050/adaptors/include/se050_default_keys.h
+++ b/lib/libnxpse050/adaptors/include/se050_default_keys.h
@@ -7,6 +7,7 @@
 #ifndef SE05X_DEFAULT_KEYS_H_
 #define SE05X_DEFAULT_KEYS_H_
 
+#include <se050_utils.h>
 #include <stdint.h>
 
 /* OF ID */
@@ -26,11 +27,41 @@
 #define SE050C2 5
 #define SE050DV 6
 
-static struct scp_key {
-	uint8_t enc[16];
-	uint8_t mac[16];
-	uint8_t dek[16];
-} se050_default_keys[] = {
+sss_status_t se050_get_id_from_ofid(uint32_t ofid, uint32_t *id)
+{
+	sss_status_t status = kStatus_SSS_Success;
+
+	switch (ofid) {
+	case SE050A1_ID:
+		*id = 0;
+		break;
+	case SE050A2_ID:
+		*id = 1;
+		break;
+	case SE050B1_ID:
+		*id = 2;
+		break;
+	case SE050B2_ID:
+		*id = 3;
+		break;
+	case SE050C1_ID:
+		*id = 4;
+		break;
+	case SE050C2_ID:
+		*id = 5;
+		break;
+	case SE050DV_ID:
+		*id = 6;
+		break;
+	default:
+		EMSG("invalid ofid");
+		status = kStatus_SSS_Fail;
+	}
+
+	return status;
+}
+
+static struct se050_scp_key se050_default_keys[] = {
 	[SE050A1] = {
 		.enc = { 0x34, 0xae, 0x09, 0x67, 0xe3, 0x29, 0xe9, 0x51,
 			 0x8e, 0x72, 0x65, 0xd5, 0xad, 0xcc, 0x01, 0xc2 },

--- a/lib/libnxpse050/adaptors/include/se050_sss_apis.h
+++ b/lib/libnxpse050/adaptors/include/se050_sss_apis.h
@@ -29,8 +29,9 @@ typedef struct {
 	sss_key_store_t host_ks;
 } sss_se05x_ctx_t;
 
-sss_status_t se050_kestore_and_object_init(sss_se05x_ctx_t *ctx);
+sss_status_t se050_key_store_and_object_init(sss_se05x_ctx_t *ctx);
 sss_status_t se050_session_open(sss_se05x_ctx_t *ctx, bool encryption);
 void se050_delete_persistent_key(uint8_t *data, size_t len);
+sss_status_t se050_rotate_spc03_keys(sss_se05x_ctx_t *ctx);
 
 #endif /* SE050_SSS_APIS_H_ */

--- a/lib/libnxpse050/adaptors/include/se050_user_apis.h
+++ b/lib/libnxpse050/adaptors/include/se050_user_apis.h
@@ -11,11 +11,16 @@
 #include <fsl_sss_se05x_types.h>
 #include <nxScp03_Types.h>
 #include <se050_sss_apis.h>
+#include <se050_utils.h>
 
 sss_status_t se050_configure_host(sss_session_t *host_session,
 				  sss_key_store_t *host_ks,
 				  SE_Connect_Ctx_t *open_ctx,
 				  struct se050_auth_ctx *auth_ctx,
-				  SE_AuthType_t auth_type);
+				  SE_AuthType_t auth_type,
+				  struct se050_scp_key *keys);
 
+sss_status_t se050_host_key_store_get_key(sss_key_store_t *ks __unused,
+					  sss_object_t *ko, uint8_t *data,
+					  size_t *byte_len, size_t *bit_len);
 #endif /* SE050_USER_APIS_H_ */

--- a/lib/libnxpse050/adaptors/include/se050_utils.h
+++ b/lib/libnxpse050/adaptors/include/se050_utils.h
@@ -38,6 +38,8 @@ uint32_t se050_ecc_keypair_from_nvm(struct ecc_keypair *key);
 uint64_t se050_generate_private_key(uint32_t oid);
 
 void se050_signature_der2bin(uint8_t *p, size_t *p_len);
+sss_status_t se050_signature_bin2der(uint8_t *signature, size_t *signature_len,
+				     uint8_t *raw, size_t raw_len);
 void se050_refcount_init_ctx(uint8_t **cnt);
 int se050_refcount_final_ctx(uint8_t *cnt);
 

--- a/lib/libnxpse050/adaptors/include/se050_utils.h
+++ b/lib/libnxpse050/adaptors/include/se050_utils.h
@@ -9,6 +9,19 @@
 
 #include <se050.h>
 
+struct se050_scp_key {
+	uint8_t enc[16];
+	uint8_t mac[16];
+	uint8_t dek[16];
+};
+
+struct s050_scp_rotate_cmd {
+	uint8_t cmd[128];
+	size_t cmd_len;
+	uint8_t kcv[16];
+	size_t kcv_len;
+};
+
 /* watermark keys to support SKS search */
 #define SE050_KEY_WATERMARK		0xDEADBEEF
 
@@ -29,5 +42,7 @@ void se050_refcount_init_ctx(uint8_t **cnt);
 int se050_refcount_final_ctx(uint8_t *cnt);
 
 void se050_display_board_info(sss_se05x_session_t *session);
-
+sss_status_t se050_prepare_rotate_cmd(sss_se05x_ctx_t *ctx,
+				      struct s050_scp_rotate_cmd *cmd,
+				      struct se050_scp_key *keys);
 #endif /* SE050_UTILS_H_ */

--- a/lib/libnxpse050/adaptors/sub.mk
+++ b/lib/libnxpse050/adaptors/sub.mk
@@ -20,6 +20,7 @@ incdirs-y += ../se050/simw-top/sss/port/default/
 incdirs-y += ../se050/simw-top/sss/src/user/crypto/
 
 # called by the core library
+srcs-y += utils/scp_config.c
 srcs-y += utils/context.c
 srcs-y += utils/utils.c
 srcs-y += utils/info.c

--- a/lib/libnxpse050/adaptors/utils/context.c
+++ b/lib/libnxpse050/adaptors/utils/context.c
@@ -27,7 +27,7 @@ static TEE_Result core_service_init(sss_se05x_ctx_t *ctx,
 	IMSG("========================");
 	IMSG(" WARNING: FACTORY RESET");
 	IMSG("========================");
-	status = se050_factory_reset(ctx);
+	status = se050_factory_reset(&ctx->session.s_ctx);
 	if (kStatus_SSS_Success != status)
 		return TEE_ERROR_GENERIC;
 #endif

--- a/lib/libnxpse050/adaptors/utils/context.c
+++ b/lib/libnxpse050/adaptors/utils/context.c
@@ -5,6 +5,7 @@
  */
 
 #include <initcall.h>
+#include <kernel/panic.h>
 #include <se050.h>
 
 sss_se05x_key_store_t		*se050_kstore;
@@ -19,10 +20,10 @@ static TEE_Result core_service_init(sss_se05x_ctx_t *ctx,
 	sss_status_t status = kStatus_SSS_Success;
 
 	status = se050_session_open(ctx, encryption);
-	if (kStatus_SSS_Success != status)
+	if (status != kStatus_SSS_Success)
 		return TEE_ERROR_GENERIC;
 
-#if CFG_CORE_SE05X_INIT_NVM
+#if defined(CFG_CORE_SE05X_INIT_NVM) && CFG_CORE_SE05X_INIT_NVM
 	IMSG("========================");
 	IMSG(" WARNING: FACTORY RESET");
 	IMSG("========================");
@@ -33,8 +34,8 @@ static TEE_Result core_service_init(sss_se05x_ctx_t *ctx,
 	if (ctx->session.subsystem == kType_SSS_SubSystem_NONE)
 		return TEE_ERROR_GENERIC;
 
-	status = se050_kestore_and_object_init(ctx);
-	if (kStatus_SSS_Success != status)
+	status = se050_key_store_and_object_init(ctx);
+	if (status != kStatus_SSS_Success)
 		return TEE_ERROR_GENERIC;
 
 	IMSG("se050 [scp03 %s]", encryption ? "ON" : "OFF");
@@ -50,19 +51,54 @@ static TEE_Result core_service_init(sss_se05x_ctx_t *ctx,
  */
 static TEE_Result se050_service_init(void)
 {
-	bool reinit = !!CFG_CORE_SE05X_DISPLAY_INFO;
+	sss_status_t status = kStatus_SSS_Success;
 	TEE_Result ret = TEE_SUCCESS;
+	bool enable_scp03 = false;
+	bool provision = false;
+	bool reinit = false;
+
+#if defined(CFG_CORE_SE05X_SCP03_PROVISION)
+	provision = !!CFG_CORE_SE05X_SCP03_PROVISION;
+#endif
+#if defined(CFG_CORE_SE05X_DISPLAY_INFO)
+	reinit = !!CFG_CORE_SE05X_DISPLAY_INFO;
+#endif
+	if (provision || !reinit)
+		enable_scp03 = true;
 
 re_initialize:
 	ret = core_service_init(&se050_ctx, &se050_session, &se050_kstore,
-				!reinit);
+				enable_scp03);
 	if (ret != TEE_SUCCESS)
-		return ret;
+		panic();
 
-	if (reinit) {
+	/* after provisioning the new keys, reboot the system and provide
+	 * a build with the new ones (until these can be read from some secured
+	 * storage - TODO)
+	 */
+	if (provision) {
+		IMSG("provisioning scp03 keys");
+		status = se050_rotate_scp03_keys(&se050_ctx);
+		if (status != kStatus_SSS_Success)
+			panic();
+
+		sss_se05x_session_close(se050_session);
+
+		IMSG("now rebuild the image with the new keys and boot it");
+		IMSG("=======================");
+		IMSG("PLEASE REBOOT THE BOARD");
+		IMSG("waiting..");
+		IMSG("======================");
+		/* do not allow further usage of the SE050 without a reboot */
+		while (true)
+			;
+	}
+
+	if (!enable_scp03) {
 		se050_display_board_info(se050_session);
 		sss_se05x_session_close(se050_session);
-		reinit = 0;
+		/* enforce scp03 */
+		enable_scp03 = true;
 		goto re_initialize;
 	}
 

--- a/lib/libnxpse050/adaptors/utils/scp_config.c
+++ b/lib/libnxpse050/adaptors/utils/scp_config.c
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (C) Foundries Ltd. 2020 - All Rights Reserved
+ * Author: Jorge Ramirez <jorge@foundries.io>
+ *
+ * This sequence follows the Global Platform Specification 2.2 - Ammendment D
+ * for Secure Channel Porotocol 03
+ *
+ */
+
+#include <se050.h>
+#include <se050_utils.h>
+#include <scp.h>
+#include <stdint.h>
+#include <string.h>
+
+static sss_status_t encrypt_key_and_get_kcv(uint8_t *enc, uint8_t *kc,
+					    uint8_t *key, sss_se05x_ctx_t *ctx,
+					    uint32_t id)
+{
+	uint8_t ones[AES_KEY_LEN_nBYTE] = { [0 ... AES_KEY_LEN_nBYTE - 1] = 1 };
+	uint8_t enc_len = AES_KEY_LEN_nBYTE;
+	uint8_t kc_len = AES_KEY_LEN_nBYTE;
+	sss_status_t st = kStatus_SSS_Fail;
+	sss_object_t *dek_object = NULL;
+	sss_se05x_symmetric_t symm = { 0 };
+	sss_se05x_object_t ko = { 0 };
+	uint8_t dek[AES_KEY_LEN_nBYTE] = { 0 };
+	size_t dek_len = sizeof(dek);
+	size_t dek_bit_len = dek_len * 8;
+
+	st = sss_se05x_key_object_init(&ko, &ctx->ks);
+	if (st != kStatus_SSS_Success)
+		return kStatus_SSS_Fail;
+
+	st = sss_se05x_key_object_allocate_handle(&ko, id,
+						  kSSS_KeyPart_Default,
+						  kSSS_CipherType_AES,
+						  AES_KEY_LEN_nBYTE,
+						  kKeyObject_Mode_Transient);
+	if (st != kStatus_SSS_Success)
+		return kStatus_SSS_Fail;
+
+	st = sss_se05x_key_store_set_key(&ctx->ks, &ko, key, AES_KEY_LEN_nBYTE,
+					 AES_KEY_LEN_nBYTE * 8, NULL, 0);
+	if (st != kStatus_SSS_Success)
+		return kStatus_SSS_Fail;
+
+	st = sss_se05x_symmetric_context_init(&symm, &ctx->session, &ko,
+					      kAlgorithm_SSS_AES_ECB,
+					      kMode_SSS_Encrypt);
+	if (st != kStatus_SSS_Success)
+		return kStatus_SSS_Fail;
+
+	st = sss_se05x_cipher_one_go(&symm, NULL, 0, ones, kc, kc_len);
+	if (st != kStatus_SSS_Success)
+		return kStatus_SSS_Fail;
+
+	/* Encyrpt the sensitive data with the scp03 dek */
+	dek_object = &ctx->open_ctx.auth.ctx.scp03.pStatic_ctx->Dek;
+	st = se050_host_key_store_get_key(&ctx->host_ks, dek_object,
+					  dek, &dek_len, &dek_bit_len);
+	if (st != kStatus_SSS_Success)
+		return kStatus_SSS_Fail;
+
+	st = sss_se05x_key_store_set_key(&ctx->ks, &ko, dek, AES_KEY_LEN_nBYTE,
+					 AES_KEY_LEN_nBYTE * 8, NULL, 0);
+	if (st != kStatus_SSS_Success)
+		return kStatus_SSS_Fail;
+
+	st = sss_se05x_cipher_one_go(&symm, NULL, 0, key, enc, enc_len);
+	if (st != kStatus_SSS_Success)
+		return kStatus_SSS_Fail;
+
+	if (symm.keyObject)
+		sss_se05x_symmetric_context_free(&symm);
+
+	sss_se05x_key_object_free(&ko);
+
+	return kStatus_SSS_Success;
+}
+
+static sss_status_t prepare_key_data(uint8_t *key, uint8_t *cmd,
+				     sss_se05x_ctx_t *ctx, uint32_t id)
+{
+	uint8_t kc[AES_KEY_LEN_nBYTE] = { 0 };
+	sss_status_t status = kStatus_SSS_Fail;
+
+	/* GP key type AES */
+	cmd[0] = PUT_KEYS_KEY_TYPE_CODING_AES;
+	/* Length of the 'AES key data' */
+	cmd[1] = AES_KEY_LEN_nBYTE + 1;
+	/* Length of 'AES key' */
+	cmd[2] = AES_KEY_LEN_nBYTE;
+	/* Length of key check  */
+	cmd[3 + AES_KEY_LEN_nBYTE] = CRYPTO_KEY_CHECK_LEN;
+
+	status = encrypt_key_and_get_kcv(&cmd[3], kc, key, ctx, id);
+	if (status != kStatus_SSS_Success)
+		return status;
+
+	memcpy(&cmd[3 + AES_KEY_LEN_nBYTE + 1], kc, CRYPTO_KEY_CHECK_LEN);
+
+	return kStatus_SSS_Success;
+}
+
+sss_status_t se050_prepare_rotate_cmd(sss_se05x_ctx_t *ctx,
+				      struct s050_scp_rotate_cmd *cmd,
+				      struct se050_scp_key *keys)
+
+{
+	sss_se05x_session_t *session = &ctx->session;
+	sss_status_t status = kStatus_SSS_Fail;
+	smStatus_t st = SM_NOT_OK;
+	size_t kcv_len = 0;
+	size_t cmd_len = 0;
+	uint8_t key_version = 0;
+	/* order of elements in the array matters */
+	uint8_t *key[] = { [0] = keys->enc,
+			   [1] = keys->mac,
+			   [2] = keys->dek,
+	};
+	uint32_t oid = 0;
+	size_t i = 0;
+
+	/* add version to replace in the header */
+	key_version = ctx->open_ctx.auth.ctx.scp03.pStatic_ctx->keyVerNo;
+
+	/* packet for SCP03 keys provision: key_version to replace */
+	cmd->cmd[cmd_len] = key_version;
+	cmd_len += 1;
+
+	cmd->kcv[kcv_len] = key_version;
+	kcv_len += 1;
+
+	for (i = 0; i < ARRAY_SIZE(key); i++) {
+		if (!key[i])
+			goto error;
+
+		status = se050_get_oid(kKeyObject_Mode_Transient, &oid);
+		if (status != kStatus_SSS_Success)
+			goto error;
+
+		status = prepare_key_data(key[i], &cmd->cmd[cmd_len], ctx, oid);
+		if (status != kStatus_SSS_Success)
+			goto error;
+
+		memcpy(&cmd->kcv[kcv_len],
+		       &cmd->cmd[cmd_len + 3 + AES_KEY_LEN_nBYTE + 1],
+		       CRYPTO_KEY_CHECK_LEN);
+
+		cmd_len += (3 + AES_KEY_LEN_nBYTE + 1 + CRYPTO_KEY_CHECK_LEN);
+		kcv_len += CRYPTO_KEY_CHECK_LEN;
+	}
+
+	cmd->cmd_len = cmd_len;
+	cmd->kcv_len = kcv_len;
+
+	return kStatus_SSS_Success;
+error:
+	EMSG("error preparing scp03 rotation command");
+
+	return kStatus_SSS_Fail;
+}

--- a/lib/libnxpse050/adaptors/utils/utils.c
+++ b/lib/libnxpse050/adaptors/utils/utils.c
@@ -175,6 +175,44 @@ void se050_signature_der2bin(uint8_t *p, size_t *p_len)
 }
 
 /*
+ * @param signature
+ * @param signature_len
+ * @param raw
+ * @param raw_len
+ */
+sss_status_t se050_signature_bin2der(uint8_t *signature, size_t *signature_len,
+				     uint8_t *raw, size_t raw_len)
+{
+	size_t der_len =  6 + raw_len;
+	size_t r_len = raw_len / 2;
+	size_t s_len = raw_len / 2;
+
+	if (*signature_len < der_len) {
+		EMSG("ECDAA Signature buffer overflow");
+		return kStatus_SSS_Fail;
+	}
+
+	if (raw_len != 48 && raw_len != 56 && raw_len != 64 && raw_len != 96) {
+		EMSG("ECDAA Invalid length in bin signature %d", raw_len);
+		return kStatus_SSS_Fail;
+	}
+
+	*signature_len = der_len;
+
+	signature[0] = 0x30;
+	signature[1] = (uint8_t)(raw_len + 4);
+	signature[2] = 0x02;
+	signature[3] = (uint8_t)r_len;
+	memcpy(&signature[4], &raw[0], r_len);
+
+	signature[3 + r_len + 1] = 0x02;
+	signature[3 + r_len + 2] = (uint8_t)s_len;
+	memcpy(&signature[3 + r_len + 3], &raw[r_len], s_len);
+
+	return kStatus_SSS_Success;
+}
+
+/*
  * @param cnt
  */
 void se050_refcount_init_ctx(uint8_t **cnt)

--- a/lib/libnxpse050/adaptors/utils/utils.c
+++ b/lib/libnxpse050/adaptors/utils/utils.c
@@ -65,8 +65,10 @@ sss_status_t se050_get_oid(sss_key_object_mode_t mode, uint32_t *val)
 	}
 
 	oid = generate_oid();
-	if (!oid)
+	if (!oid) {
+		EMSG("cant access rng");
 		return kStatus_SSS_Fail;
+	}
 
 	if (type == kKeyObject_Mode_Persistent) {
 		IMSG("allocated persistent object: 0x%x", oid);

--- a/lib/libnxpse050/core/ecc.c
+++ b/lib/libnxpse050/core/ecc.c
@@ -332,7 +332,7 @@ TEE_Result crypto_acipher_ecc_verify(uint32_t algo, struct ecc_public_key *key,
 	sss_se05x_asymmetric_t ctx = { 0 };
 	sss_se05x_object_t kobject = { 0 };
 	TEE_Result res = TEE_SUCCESS;
-	uint8_t signature[256];
+	uint8_t signature[128];
 	size_t signature_len = sizeof(signature);
 	size_t key_bytes = 0;
 	size_t key_bits = 0;
@@ -353,8 +353,8 @@ TEE_Result crypto_acipher_ecc_verify(uint32_t algo, struct ecc_public_key *key,
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	st = sss_util_asn1_ecdaa_get_signature(signature, &signature_len,
-					       (uint8_t *)sig, sig_len);
+	st = se050_signature_bin2der(signature, &signature_len,
+				     (uint8_t *)sig, sig_len);
 	if (st != kStatus_SSS_Success) {
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto exit;

--- a/lib/libnxpse050/core/ecc.c
+++ b/lib/libnxpse050/core/ecc.c
@@ -480,7 +480,7 @@ TEE_Result crypto_acipher_ecc_shared_secret(struct ecc_keypair *private_key,
 		free(key.x);
 		return ret;
 	}
-	st = se050_ecc_gen_shared_secret(se050_session, kid, &key,
+	st = se050_ecc_gen_shared_secret(&se050_session->s_ctx, kid, &key,
 					 secret, secret_len);
 	free(key.x);
 	free(key.y);


### PR DESCRIPTION
Tested in imx8evk

**Shared Secret:**
1)  lmp-device-register -n ecdh-imx8mmevk-001  -m /usr/lib/libsks.so.0.0 
2) pkcs11-tool --module /usr/lib/libsks.so.0.0 --keypairgen --key-type EC:prime256v1 --id 02 
3) pkcs11-tool --module /usr/lib/libsks.so.0.0 --read-object --type pubkey --id 02 -o /tmp/pub.der
4) pkcs11-tool --module /usr/lib/libsks.so.0.0  --id 01 --derive --input-file /tmp/pub.der -m ECDH1-DERIVE --output-file /tmp/bytes 

**SCP03 Rotation:**
Follow the op-tee configuration options defined in the commit and boot the bootloader.

> **NOTICE**: The SE050 scp03 keys can not be reset to its default values without having access to working values: ie, once the keys are rotated, the new keys MUST not be lost since there is no alternate procedure to reprogram them.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
