### PR TITLE
[FIO toup] libnxpse050: glue: lock i2c transfers

### DIFF
--- a/lib/libnxpse050/se050/glue/smCom.c
+++ b/lib/libnxpse050/se050/glue/smCom.c
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (C) Foundries Ltd. 2020 - All Rights Reserved
+ * Author: Jorge Ramirez <jorge@foundries.io>
+ */
+#include <kernel/mutex.h>
+#include <smCom.h>
+#include <stdio.h>
+#include <trace.h>
+
+static ApduTransceiveRawFunction_t transceive_raw;
+static ApduTransceiveFunction_t transceive;
+static struct mutex lock = MUTEX_INITIALIZER;
+
+void smCom_Init(ApduTransceiveFunction_t t, ApduTransceiveRawFunction_t traw)
+{
+	transceive_raw = traw;
+	transceive = t;
+}
+
+void smCom_DeInit(void)
+{
+	mutex_lock(&lock);
+	transceive_raw = NULL;
+	transceive = NULL;
+	mutex_unlock(&lock);
+}
+
+uint32_t smCom_Transceive(void *ctx, apdu_t *apdu)
+{
+	uint32_t ret = SMCOM_NO_PRIOR_INIT;
+
+	if (!transceive)
+		return ret;
+
+	mutex_lock(&lock);
+	ret = transceive(ctx, apdu);
+	mutex_unlock(&lock);
+
+	return ret;
+}
+
+uint32_t smCom_TransceiveRaw(void *ctx, uint8_t *tx, uint16_t tx_len,
+			     uint8_t *rx, uint32_t *rx_len)
+{
+	uint32_t ret = SMCOM_NO_PRIOR_INIT;
+
+	if (!transceive_raw)
+		return ret;
+
+	mutex_lock(&lock);
+	ret = transceive_raw(ctx, tx, tx_len, rx, rx_len);
+	mutex_unlock(&lock);
+
+	return ret;
+}

--- a/lib/libnxpse050/se050/sub.mk
+++ b/lib/libnxpse050/se050/sub.mk
@@ -25,10 +25,10 @@ incdirs-y += ./simw-top/sss/src/user/crypto/
 srcs-y += glue/stubs.c
 srcs-y += glue/wraps.c
 srcs-y += glue/i2c.c
+srcs-y += glue/smCom.c
 
 # hostlib/hostLib/libCommon/smCom/
 srcs-y += simw-top/hostlib/hostLib/libCommon/smCom/smComT1oI2C.c
-srcs-y += simw-top/hostlib/hostLib/libCommon/smCom/smCom.c
 
 # hostlib/hostLib/libCommon/smCom/T1oI2C/
 srcs-y += simw-top/hostlib/hostLib/libCommon/smCom/T1oI2C/phNxpEse_Api.c


### PR DESCRIPTION
Since we can't enable the pthread lock used in the middleware
(smCom.c), the functionality using the lock must be replicated in the
glue.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
