### PR TITLE
[FIO toup] drivers: rng_pta

### DIFF
--- a/core/drivers/rng_pta.c
+++ b/core/drivers/rng_pta.c
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2018, Linaro Limited
+ * Copyright (C) 2020, Foundries Limited
+ */
+
+#include <crypto/crypto.h>
+#include <kernel/delay.h>
+#include <kernel/pseudo_ta.h>
+#include <kernel/spinlock.h>
+#include <kernel/timer.h>
+#include <mm/core_memprot.h>
+#include <io.h>
+#include <string.h>
+#include <drivers/rng_pta_client.h>
+
+#define PTA_NAME "rng.pta"
+
+static TEE_Result rng_get_entropy(uint32_t types,
+				  TEE_Param params[TEE_NUM_PARAMS])
+{
+	uint8_t *e = NULL;
+	uint32_t rq_size = 0;
+	uint32_t exceptions;
+	TEE_Result res = TEE_SUCCESS;
+
+	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE)) {
+		EMSG("bad parameters types: 0x%" PRIx32, types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	rq_size = params[0].memref.size;
+	e = (uint8_t *)params[0].memref.buffer;
+	if (!e)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
+
+	res = crypto_rng_read(e, rq_size);
+
+	thread_set_exceptions(exceptions);
+
+	return res;
+}
+
+static TEE_Result rng_get_info(uint32_t types,
+			       TEE_Param params[TEE_NUM_PARAMS])
+{
+	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE)) {
+		EMSG("bad parameters types: 0x%" PRIx32, types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/*
+	 * value.a is data rate: calls to crypto rng will always generate
+	 * the requested number of bytes from the RNG device therefore there
+	 * is no need to artificially wait for it to generate additional data.
+	 */
+	params[0].value.a = UINT32_MAX;
+
+	/*
+	 * value.b is quality: 0 (unknown), 1 (lowest) and 1024(highest)
+	 * HW dependent true entropy estimation set this to 1024.
+	 */
+	params[0].value.b = 1024;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result invoke_command(void *pSessionContext __unused,
+				 uint32_t nCommandID, uint32_t nParamTypes,
+				 TEE_Param pParams[TEE_NUM_PARAMS])
+{
+	FMSG("command entry point for pseudo-TA \"%s\"", PTA_NAME);
+
+	switch (nCommandID) {
+	case PTA_CMD_GET_ENTROPY:
+		return rng_get_entropy(nParamTypes, pParams);
+	case PTA_CMD_GET_RNG_INFO:
+		return rng_get_info(nParamTypes, pParams);
+	default:
+		break;
+	}
+
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+pseudo_ta_register(.uuid = PTA_RNG_UUID, .name = PTA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS | TA_FLAG_DEVICE_ENUM,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -32,5 +32,6 @@ srcs-$(CFG_STPMIC1) += stpmic1.c
 srcs-$(CFG_BCM_HWRNG) += bcm_hwrng.c
 srcs-$(CFG_BCM_SOTP) += bcm_sotp.c
 srcs-$(CFG_BCM_GPIO) += bcm_gpio.c
+srcs-$(CFG_RNG_PTA) += rng_pta.c
 
 subdirs-y += crypto

--- a/core/include/drivers/rng_pta_client.h
+++ b/core/include/drivers/rng_pta_client.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2018, Linaro Limited
+ */
+
+#ifndef __RNG_PTA_CLIENT_H
+#define __RNG_PTA_CLIENT_H
+
+#define PTA_RNG_UUID { 0x035a4479, 0xc369, 0x47f4, \
+		{ 0x94, 0x51, 0xc6, 0xfd, 0xff, 0x28, 0xad, 0x65 } }
+
+/*
+ * PTA_CMD_GET_ENTROPY - Get Entropy from RNG using crypto_rng_read()
+ *
+ * param[0] (inout memref) - Entropy buffer memory reference
+ * param[1] unused
+ * param[2] unused
+ * param[3] unused
+ *
+ * Result:
+ * TEE_SUCCESS - Invoke command success
+ * TEE_ERROR_BAD_PARAMETERS - Incorrect input param
+ * TEE_ERROR_NOT_SUPPORTED - Requested entropy size greater than size of pool
+ * TEE_ERROR_HEALTH_TEST_FAIL - Continuous health testing failed
+ */
+#define PTA_CMD_GET_ENTROPY		0x0
+
+/*
+ * PTA_CMD_GET_RNG_INFO - Get RNG information
+ *
+ * param[0] (out value) - value.a: RNG data-rate in bytes per second
+ *                        value.b: Quality/Entropy per 1024 bit of data
+ * param[1] unused
+ * param[2] unused
+ * param[3] unused
+ *
+ * Result:
+ * TEE_SUCCESS - Invoke command success
+ * TEE_ERROR_BAD_PARAMETERS - Incorrect input param
+ */
+#define PTA_CMD_GET_RNG_INFO		0x1
+
+#endif /* __RNG_PTA_CLIENT_H */


### PR DESCRIPTION
Add a Pseudo-TA to expose the crypto RNG from OPTEE.

This uses a generic call to crypto_rng_read() to supply the
random data.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
