### PR TITLE
[FIO toup] libnxpse050: apdu: fix rsa/ecc key injection

### DIFF
--- a/lib/libnxpse050/adaptors/apis/apdu.c
+++ b/lib/libnxpse050/adaptors/apis/apdu.c
@@ -565,7 +565,7 @@ sss_status_t se050_key_store_set_ecc_key_bin(sss_se05x_key_store_t *store,
 					     struct ecc_keypair_bin *key_pair,
 					     struct ecc_public_key_bin *key_pub)
 {
-	SE05x_TransientType_t type = kSE05x_TransientType_Persistent;
+	SE05x_INS_t type = kSE05x_INS_TRANSIENT;
 	size_t public_keylen = 0;
 	uint8_t buffer[256] = { 0x04 }; /* tag */
 	uint8_t *public_key = buffer + 1;
@@ -581,8 +581,8 @@ sss_status_t se050_key_store_set_ecc_key_bin(sss_se05x_key_store_t *store,
 
 	s_ctx = &store->session->s_ctx;
 	k_object->curve_id = key_pair ? key_pair->curve : key_pub->curve;
-	type = k_object->isPersistant ? kSE05x_TransientType_Persistent :
-				  kSE05x_TransientType_Transient;
+	if (k_object->isPersistant)
+		type = kSE05x_INS_NA;
 
 	if (k_object->objectType != kSSS_KeyPart_Pair)
 		goto label_public;

--- a/lib/libnxpse050/adaptors/apis/apdu.c
+++ b/lib/libnxpse050/adaptors/apis/apdu.c
@@ -96,7 +96,7 @@ sss_status_t se050_key_store_set_rsa_key_bin(sss_se05x_key_store_t *store,
 					     size_t key_bit_len)
 {
 	SE05x_RSAKeyFormat_t rsa_format = kSE05x_RSAKeyFormat_RAW;
-	SE05x_TransientType_t type = kSE05x_TransientType_Transient;
+	SE05x_INS_t type = kSE05x_INS_TRANSIENT;
 	Se05xSession_t *s_ctx = NULL;
 	uint32_t key_type = 0;
 	Se05xPolicy_t policy = {
@@ -111,7 +111,7 @@ sss_status_t se050_key_store_set_rsa_key_bin(sss_se05x_key_store_t *store,
 	s_ctx = &store->session->s_ctx;
 	key_type = k_object->objectType;
 	if (k_object->isPersistant)
-		type = kSE05x_TransientType_Persistent;
+		type = kSE05x_INS_NA;
 
 	switch (k_object->cipherType) {
 	case kSSS_CipherType_RSA:
@@ -149,7 +149,7 @@ sss_status_t se050_key_store_set_rsa_key_bin(sss_se05x_key_store_t *store,
 				       kSE05x_KeyPart_Public,
 				       rsa_format);
 	if (status != SM_OK) {
-		EMSG("keybitlen %ld, e_len %ld", key_bit_len, key_pub->e_len);
+		EMSG("keybitlen %ld, e_len %ld, status = 0x%x", key_bit_len, key_pub->e_len, status);
 		ret = kStatus_SSS_Fail;
 		goto exit;
 	}


### PR DESCRIPTION
The wrong APDU command was being sent to the SE050 for transient keys.
Verified against the original SE050 stack

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

Original code: 
function: sss_se05x_key_store_set_rsa_key 
file:        sss/src/se05x/fsl_sss_se05x_apis.c

Ported code:
function: se050_key_store_set_rsa_key_bin
file: lib/libnxpse050/adaptors/apis/apdu.c

Issue: the type represents a field in the APDU command sent to the SE05. We were sending the wrong instruction byte.
