### PR TITLE
3.10+fio.rel74 fixes

### DIFF
--- a/core/arch/arm/kernel/rpc_io_i2c.c
+++ b/core/arch/arm/kernel/rpc_io_i2c.c
@@ -38,7 +38,7 @@ TEE_Result rpc_io_i2c_transfer(struct rpc_i2c_request *req, size_t *len)
 		memcpy(va, req->buffer, req->buffer_len);
 
 	p[0] = THREAD_PARAM_VALUE(IN, req->mode, req->bus, req->chip);
-	p[1] = THREAD_PARAM_VALUE(IN, req->flags, 0, 0);
+	p[1] = THREAD_PARAM_VALUE(IN, req->flags, req->retries, 0);
 	p[2] = THREAD_PARAM_MEMREF(INOUT, mobj, 0, req->buffer_len);
 	p[3] = THREAD_PARAM_VALUE(OUT, 0, 0, 0);
 

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -114,6 +114,17 @@ struct thread_core_local thread_core_local[CFG_TEE_CORE_NB_CORE] __nex_bss;
 #define STACK_CHECK_EXTRA	0
 #endif
 
+/*
+ * Extra space can be added to the TMP and THREAD stacks when the defaults are
+ * not sufficient for certain configurations
+ */
+#ifndef CFG_STACK_TMP_EXTRA
+#define CFG_STACK_TMP_EXTRA	0
+#endif
+#ifndef CFG_STACK_THREAD_EXTRA
+#define CFG_STACK_THREAD_EXTRA	0
+#endif
+
 #define DECLARE_STACK(name, num_stacks, stack_size, linkage) \
 linkage uint32_t name[num_stacks] \
 		[ROUNDUP(stack_size + STACK_CANARY_SIZE + STACK_CHECK_EXTRA, \
@@ -123,10 +134,12 @@ linkage uint32_t name[num_stacks] \
 
 #define GET_STACK(stack) ((vaddr_t)(stack) + STACK_SIZE(stack))
 
-DECLARE_STACK(stack_tmp, CFG_TEE_CORE_NB_CORE, STACK_TMP_SIZE, static);
+DECLARE_STACK(stack_tmp, CFG_TEE_CORE_NB_CORE,
+	      STACK_TMP_SIZE + CFG_STACK_TMP_EXTRA, static);
 DECLARE_STACK(stack_abt, CFG_TEE_CORE_NB_CORE, STACK_ABT_SIZE, static);
 #ifndef CFG_WITH_PAGER
-DECLARE_STACK(stack_thread, CFG_NUM_THREADS, STACK_THREAD_SIZE, static);
+DECLARE_STACK(stack_thread, CFG_NUM_THREADS,
+	      STACK_THREAD_SIZE + CFG_STACK_THREAD_EXTRA, static);
 #endif
 
 #define GET_STACK_TOP_HARD(stack, n) \

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -123,18 +123,12 @@ linkage uint32_t name[num_stacks] \
 
 #define GET_STACK(stack) ((vaddr_t)(stack) + STACK_SIZE(stack))
 
-DECLARE_STACK(stack_abt, CFG_TEE_CORE_NB_CORE, STACK_ABT_SIZE, static);
-#ifdef CFG_NXP_SE05X_SVC
-DECLARE_STACK(stack_tmp, CFG_TEE_CORE_NB_CORE, 5 * STACK_TMP_SIZE, static);
-#ifndef CFG_WITH_PAGER
-DECLARE_STACK(stack_thread, CFG_NUM_THREADS, 2 * STACK_THREAD_SIZE, static);
-#endif
-#else
 DECLARE_STACK(stack_tmp, CFG_TEE_CORE_NB_CORE, STACK_TMP_SIZE, static);
+DECLARE_STACK(stack_abt, CFG_TEE_CORE_NB_CORE, STACK_ABT_SIZE, static);
 #ifndef CFG_WITH_PAGER
 DECLARE_STACK(stack_thread, CFG_NUM_THREADS, STACK_THREAD_SIZE, static);
 #endif
-#endif
+
 #define GET_STACK_TOP_HARD(stack, n) \
 	((vaddr_t)&(stack)[n] + STACK_CANARY_SIZE / 2)
 #define GET_STACK_TOP_SOFT(stack, n) \

--- a/core/arch/arm/plat-imx/crypto_conf.mk
+++ b/core/arch/arm/plat-imx/crypto_conf.mk
@@ -46,8 +46,10 @@ $(call force, CFG_NXP_CAAM_RUNTIME_JR, y)
 #
 # Definition of all HW accelerations for all i.MX
 #
-$(call force, CFG_NXP_CAAM_RNG_DRV, y)
-$(call force, CFG_WITH_SOFTWARE_PRNG,n)
+CFG_NXP_CAAM_RNG_DRV ?= y
+ifeq ($(CFG_NXP_CAAM_RNG_DRV), y)
+$(call force, CFG_WITH_SOFTWARE_PRNG, n)
+endif
 
 # Force to 'y' the CFG_NXP_CAAM_xxx_DRV to enable the CAAM HW driver
 # and enable the associated CFG_CRYPTO_DRV_xxx Crypto driver

--- a/core/arch/arm/plat-imx/crypto_conf.mk
+++ b/core/arch/arm/plat-imx/crypto_conf.mk
@@ -1,4 +1,3 @@
-include mk/config.mk
 #
 # Define the cryptographic algorithm to be built
 #
@@ -47,14 +46,8 @@ $(call force, CFG_NXP_CAAM_RUNTIME_JR, y)
 #
 # Definition of all HW accelerations for all i.MX
 #
-ifeq ($(CFG_CORE_SE05X), y)
-$(call force, CFG_NXP_CAAM_RNG_DRV, n)
-CFG_CRYPTO_DRIVER_DEBUG = 0
-else
 $(call force, CFG_NXP_CAAM_RNG_DRV, y)
-endif
-
-CFG_WITH_SOFTWARE_PRNG = n
+$(call force, CFG_WITH_SOFTWARE_PRNG,n)
 
 # Force to 'y' the CFG_NXP_CAAM_xxx_DRV to enable the CAAM HW driver
 # and enable the associated CFG_CRYPTO_DRV_xxx Crypto driver

--- a/core/core.mk
+++ b/core/core.mk
@@ -99,6 +99,28 @@ libname = utils
 libdir = lib/libutils
 include mk/lib.mk
 
+ifeq ($(CFG_CORE_SE05X), y)
+CFG_CORE_SE05X_I2C_BUS ?= 0x2
+CFG_CORE_SE05X_BAUDRATE ?= 3400000
+CFG_CORE_SE05X_INIT_NVM ?= n
+CFG_CORE_SE05X_SCP03_PROVISION ?= n
+CFG_CORE_SE05X_SCP03_EARLY ?= y
+CFG_CORE_SE05X_DISPLAY_INFO ?= y
+CFG_CORE_SE05X_OEFID ?= n
+CFG_STACK_THREAD_EXTRA ?= 8192
+CFG_STACK_TMP_EXTRA ?= 8192
+$(call force, CFG_CRYPTO_RSASSA_NA1, n, not supported by se050)
+$(call force, CFG_NXP_SE05X_SVC, y)
+$(call force, CFG_NXP_SE05X_HMAC_DRV, y)
+# if the platform already implements an RNG driver, it must be
+# disabled or it will conflict with the one provided by the SE05X
+# library
+$(call force, CFG_NXP_SE05X_RNG_DRV, y)
+libname = nxpse050
+libdir = lib/libnxpse050
+include mk/lib.mk
+endif
+
 # CFG_CRYPTOLIB_NAME must not be changed beyond this line
 CFG_CRYPTOLIB_NAME_$(CFG_CRYPTOLIB_NAME) := y
 

--- a/core/core.mk
+++ b/core/core.mk
@@ -99,21 +99,6 @@ libname = utils
 libdir = lib/libutils
 include mk/lib.mk
 
-ifeq ($(CFG_CORE_SE05X), y)
-
-CFG_CORE_SE05X_I2C_BUS ?= 0x2
-CFG_CORE_SE05X_BAUDRATE ?= 3400000
-CFG_CORE_SE05X_INIT_NVM ?= 0
-
-$(call force, CFG_CRYPTO_RSASSA_NA1, n, not supported by se050)
-$(call force, CFG_NXP_SE05X_SVC, y)
-$(call force, CFG_NXP_SE05X_HMAC_DRV, y)
-$(call force, CFG_NXP_SE05X_RNG_DRV, y)
-libname = nxpse050
-libdir = lib/libnxpse050
-include mk/lib.mk
-endif
-
 # CFG_CRYPTOLIB_NAME must not be changed beyond this line
 CFG_CRYPTOLIB_NAME_$(CFG_CRYPTOLIB_NAME) := y
 

--- a/core/include/kernel/rpc_io_i2c.h
+++ b/core/include/kernel/rpc_io_i2c.h
@@ -29,6 +29,7 @@ struct rpc_i2c_request {
 	uint16_t bus; /* bus identifier used by the REE [0..n] */
 	uint16_t chip; /* slave identifier from its data sheet */
 	uint16_t flags; /* transfer flags (ie: ten bit chip address) */
+	uint16_t retries; /* bus adaptor transfer retries */
 	uint8_t *buffer;
 	size_t buffer_len;
 };

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -158,6 +158,8 @@
  *				16 bit field (either 7 or 10 bit effective).
  * [in]     value[1].a	    The I2C master control flags (ie, 10 bit address).
  *				16 bit field.
+ * [in]     value[1].b	    The I2C bus retry attempts.
+ *				16 bit field.
  * [in/out] memref[2]	    Buffer used for data transfers.
  * [out]    value[3].a	    Number of bytes transferred by the REE.
  */

--- a/lib/libnxpse050/se050/glue/i2c.c
+++ b/lib/libnxpse050/se050/glue/i2c.c
@@ -39,6 +39,7 @@ static int i2c_transfer(uint8_t *buffer, int len, enum rpc_i2c_mode mode)
 		.buffer = buffer,
 		.buffer_len = len,
 		.flags = 0,
+		.retries = 20,
 	};
 	size_t bytes = 0;
 	int retry = 5;
@@ -46,7 +47,7 @@ static int i2c_transfer(uint8_t *buffer, int len, enum rpc_i2c_mode mode)
 	do {
 		if ((*transfer)(&request, &bytes) == TEE_SUCCESS)
 			return bytes;
-	} while (--retry);
+	} while (--retry && (transfer != &rpc_io_i2c_transfer));
 
 	return -1;
 }

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -570,18 +570,10 @@ CFG_TA_MBEDTLS_SELF_TEST ?= y
 CFG_CRYPTOLIB_NAME ?= tomcrypt
 CFG_CRYPTOLIB_DIR ?= core/lib/libtomcrypt
 
-# Library stack to support communication with NXP's SE050 Middleware
-CFG_CORE_SE05X ?= n
-
 # Enable TEE_ALG_RSASSA_PKCS1_V1_5 algorithm for signing with PKCS#1 v1.5 EMSA
 # without ASN.1 around the hash.
 ifeq ($(CFG_CRYPTOLIB_NAME),tomcrypt)
-ifneq ($(CFG_CORE_SE05X), y)
 CFG_CRYPTO_RSASSA_NA1 ?= y
-else
-CFG_WITH_SOFTWARE_PRNG = n
-endif
-CFG_CORE_MBEDTLS_MPI ?= y
 endif
 
 # Not used since libmpa was removed. Force the value to catch build scripts

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -570,10 +570,18 @@ CFG_TA_MBEDTLS_SELF_TEST ?= y
 CFG_CRYPTOLIB_NAME ?= tomcrypt
 CFG_CRYPTOLIB_DIR ?= core/lib/libtomcrypt
 
+# Library stack to support communication with NXP's SE050 Middleware
+CFG_CORE_SE05X ?= n
+
 # Enable TEE_ALG_RSASSA_PKCS1_V1_5 algorithm for signing with PKCS#1 v1.5 EMSA
 # without ASN.1 around the hash.
 ifeq ($(CFG_CRYPTOLIB_NAME),tomcrypt)
+ifneq ($(CFG_CORE_SE05X), y)
 CFG_CRYPTO_RSASSA_NA1 ?= y
+else
+CFG_WITH_SOFTWARE_PRNG = n
+endif
+CFG_CORE_MBEDTLS_MPI ?= y
 endif
 
 # Not used since libmpa was removed. Force the value to catch build scripts


### PR DESCRIPTION
1) use the CAAM RNG driver (since library symbols can not overload _weak symbols, the CAAM RNG driver will take precedence)
2) add retry field to the i2c master transfers (requires a kernel companion patch)