### PR TITLE
RSA/ECC, request SE pre-provisioned keys

### DIFF
--- a/lib/libnxpse050/adaptors/include/se050_utils.h
+++ b/lib/libnxpse050/adaptors/include/se050_utils.h
@@ -43,7 +43,7 @@ uint64_t se050_generate_private_key(uint32_t oid);
 void se050_signature_der2bin(uint8_t *p, size_t *p_len);
 sss_status_t se050_signature_bin2der(uint8_t *signature, size_t *signature_len,
 				     uint8_t *raw, size_t raw_len);
-
+TEE_Result se050_oid_from_criptoki_label(uint8_t **p, uint32_t *oid);
 void se050_refcount_init_ctx(uint8_t **cnt);
 int se050_refcount_final_ctx(uint8_t *cnt);
 

--- a/lib/libnxpse050/core/rsa.c
+++ b/lib/libnxpse050/core/rsa.c
@@ -197,6 +197,17 @@ TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t kb)
 	if (st != kStatus_SSS_Success)
 		return TEE_ERROR_BAD_PARAMETERS;
 
+	if (se050_oid_from_criptoki_label(&key->d, &oid) != TEE_SUCCESS)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (oid) {
+		st = sss_se05x_key_object_get_handle(&k_object, oid);
+		if (st != kStatus_SSS_Success)
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		goto get_key;
+	}
+
 	st = se050_get_oid(kKeyObject_Mode_Persistent, &oid);
 	if (st != kStatus_SSS_Success)
 		return TEE_ERROR_GENERIC;
@@ -215,6 +226,7 @@ TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t kb)
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
+get_key:
 	st = sss_se05x_key_store_get_key(se050_kstore, &k_object, k, &k_len,
 					 &kb);
 	if (st != kStatus_SSS_Success) {


### PR DESCRIPTION
Allow the criptoki client to request specific keys from the SE (ie,
those set during manufacturing).

The criptoki client would request the key using the label field at
creation time:
ie --label SE_XXXXXXXX (SE_ mark + 32 bit field representing the keyid
in hex)

pkcs11-tool --module /usr/lib/libsks.so.0.0
	    --keypairgen
	    --key-type RSA:4096
	    --id 01
	    --label SE_7F001010
	    --token-label aktualizr
	    --pin 87654321

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
