### PR TITLE
[FIO toup] libnxpse050: support TEE_ALG_RSASSA_PKCS1_V1_5

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -109,7 +109,7 @@ CFG_CORE_SE05X_DISPLAY_INFO ?= y
 CFG_CORE_SE05X_OEFID ?= n
 CFG_STACK_THREAD_EXTRA ?= 8192
 CFG_STACK_TMP_EXTRA ?= 8192
-$(call force, CFG_CRYPTO_RSASSA_NA1, n, not supported by se050)
+CFG_CRYPTO_RSASSA_NA1 ?= y
 $(call force, CFG_NXP_SE05X_SVC, y)
 $(call force, CFG_NXP_SE05X_HMAC_DRV, y)
 # if the platform already implements an RNG driver, it must be

--- a/lib/libnxpse050/core/rsa.c
+++ b/lib/libnxpse050/core/rsa.c
@@ -9,6 +9,7 @@
 #include <kernel/panic.h>
 #include <se050.h>
 #include <string.h>
+#include <tee_api_defines_extensions.h>
 
 static uint32_t tee2se050(uint32_t algo)
 {
@@ -49,6 +50,7 @@ static uint32_t tee2se050(uint32_t algo)
 		return kAlgorithm_SSS_RSASSA_NO_PADDING;
 #ifdef CFG_CRYPTO_RSASSA_NA1
 	case TEE_ALG_RSASSA_PKCS1_V1_5:
+		return kAlgorithm_SSS_RSASSA_PKCS1_V1_5_NO_HASH;
 #endif
 	case TEE_ALG_RSASSA_PKCS1_V1_5_MD5:
 	case TEE_ALG_RSASSA_PKCS1_V1_5_MD5SHA1:


### PR DESCRIPTION
RSA sign/verify without hash.

To test (similar for libsofthsm2.so)

 sign:
   pkcs11-tool  --module /usr/lib/libsks.so.0.0
    		--sign -m RSA-PKCS
		--pin 87654321 --id 01
		--input-file message
		--output-file message.sig
		-f openssl

 verify:
   pkcs11-tool  --module /usr/lib/libsks.so.0.0
   	       	--verify -m RSA-PKCS
		--pin 87654321 --id 01
		--signature-file message.sig
		--input-file message
		-f openssl

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
