### PR TITLE
[FIO toup] libnxpse050: remove error message

### DIFF
--- a/lib/libnxpse050/adaptors/apis/sss.c
+++ b/lib/libnxpse050/adaptors/apis/sss.c
@@ -279,23 +279,27 @@ void se050_delete_persistent_key(uint8_t *data, size_t len)
 	p = p - 4;
 	memcpy((void *)&val, p, sizeof(val));
 
+	/* customer key range */
+	if (!val || val > 0x7BFFFFFF)
+		return;
+
 	status = sss_se05x_key_object_init(&k_object, se050_kstore);
 	if (status != kStatus_SSS_Success) {
-		EMSG("error deleting persistent key");
+		EMSG("can't delete key 0x%x\n", val);
 		return;
 	}
 
 	status = sss_se05x_key_object_get_handle(&k_object, val);
 	if (status != kStatus_SSS_Success) {
-		EMSG("error deleting persistent key");
+		EMSG("can't delete key 0x%x\n", val);
 		return;
 	}
 
 	status = sss_se05x_key_store_erase_key(se050_kstore, &k_object);
 	if (status != kStatus_SSS_Success) {
-		EMSG("error deleting persistent key");
+		EMSG("can't delete key 0x%x\n", val);
 		return;
 	}
 
-	IMSG("deleted se050 persistent key 0x%x", val);
+	IMSG("se050: deleted key 0x%x\n", val);
 }


### PR DESCRIPTION
Keys outside the user range for can not be deleted and therefore the
stack should not attempt to remove them.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
