### PR TITLE
Fio v3.10 imx6 sec fix

### DIFF
--- a/core/arch/arm/plat-imx/drivers/imx_snvs.c
+++ b/core/arch/arm/plat-imx/drivers/imx_snvs.c
@@ -18,11 +18,11 @@ bool plat_rpmb_key_is_ready(void)
 		      mode == SNVS_SSM_MODE_SECURE);
 
 	/*
-	 * On i.MX6SDL, the security cfg always returns
+	 * On i.MX6SDL and i.MX6Q, the security cfg always returns
 	 * SNVS_SECURITY_CFG_FAB (000), therefore we ignore the security
 	 * configuration for this SoC.
 	 */
-	if (soc_is_imx6sdl())
+	if (soc_is_imx6sdl() || soc_is_imx6dq())
 		return ssm_secure;
 
 	return ssm_secure && (security == SNVS_SECURITY_CFG_CLOSED);

--- a/core/arch/arm/plat-imx/drivers/imx_snvs.c
+++ b/core/arch/arm/plat-imx/drivers/imx_snvs.c
@@ -3,16 +3,27 @@
  * Copyright 2020 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
  */
 #include <drivers/imx_snvs.h>
+#include <imx.h>
 #include <tee/tee_fs.h>
 
 bool plat_rpmb_key_is_ready(void)
 {
 	enum snvs_ssm_mode mode = SNVS_SSM_MODE_INIT;
 	enum snvs_security_cfg security = SNVS_SECURITY_CFG_OPEN;
+	bool ssm_secure = false;
 
 	mode = snvs_get_ssm_mode();
 	security = snvs_get_security_cfg();
-	return (mode == SNVS_SSM_MODE_TRUSTED ||
-		mode == SNVS_SSM_MODE_SECURE) &&
-		(security == SNVS_SECURITY_CFG_CLOSED);
+	ssm_secure = (mode == SNVS_SSM_MODE_TRUSTED ||
+		      mode == SNVS_SSM_MODE_SECURE);
+
+	/*
+	 * On i.MX6SDL, the security cfg always returns
+	 * SNVS_SECURITY_CFG_FAB (000), therefore we ignore the security
+	 * configuration for this SoC.
+	 */
+	if (soc_is_imx6sdl())
+		return ssm_secure;
+
+	return ssm_secure && (security == SNVS_SECURITY_CFG_CLOSED);
 }


### PR DESCRIPTION
These 2 patches address a flaw in the handling of the SNVS HPSR register on i.MX6 SoC.

The first patch was pulled from the 3.13 OP-TEE tree and the second was an addition to that patch needed for IMX6Q SoC.