### PR TITLE
[FIO internal] ta: fiovb: copy data to temporary buffers

### DIFF
--- a/ta/fiovb/entry.c
+++ b/ta/fiovb/entry.c
@@ -75,13 +75,18 @@ static TEE_Result write_persist_value(uint32_t pt,
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	char *value = params[1].memref.buffer;
 	uint32_t value_sz = params[1].memref.size;
+	char *value = TEE_Malloc(value_sz, 0);
+	if (!value)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	TEE_MemMove(value, params[1].memref.buffer,
+		    value_sz);
 
 	res = get_named_object_name(name_buf, name_buf_sz,
 				    name_full, &name_full_sz);
 	if (res)
-		return res;
+		goto out;
 
 	res = TEE_CreatePersistentObject(storageid, name_full,
 					 name_full_sz,
@@ -91,6 +96,8 @@ static TEE_Result write_persist_value(uint32_t pt,
 		EMSG("Can't create named object value, res = 0x%x", res);
 
 	TEE_CloseObject(h);
+out:
+	TEE_Free(value);
 
 	return res;
 }
@@ -123,19 +130,21 @@ static TEE_Result read_persist_value(uint32_t pt,
 
 	uint32_t name_buf_sz = params[0].memref.size;
 
-	char *value = params[1].memref.buffer;
 	uint32_t value_sz = params[1].memref.size;
+	char *value = TEE_Malloc(value_sz, 0);
+	if (!value)
+		return TEE_ERROR_OUT_OF_MEMORY;
 
 	res = get_named_object_name(name_buf, name_buf_sz,
 				    name_full, &name_full_sz);
 	if (res)
-		return res;
+		goto out_free;
 
 	res = TEE_OpenPersistentObject(storageid, name_full,
 				       name_full_sz, flags, &h);
 	if (res) {
 		EMSG("Can't open named object value, res = 0x%x", res);
-		return res;
+		goto out_free;
 	}
 
 	res =  TEE_ReadObjectData(h, value, value_sz, &count);
@@ -144,9 +153,14 @@ static TEE_Result read_persist_value(uint32_t pt,
 		goto out;
 	}
 
+	TEE_MemMove(params[1].memref.buffer, value,
+		    value_sz);
+
 	params[1].memref.size = count;
 out:
 	TEE_CloseObject(h);
+out_free:
+	TEE_Free(value);
 
 	return res;
 }


### PR DESCRIPTION
```
Use intermediate temporary buffers instead of directly supplying
non-secure buffers to TEE_ReadObjectData()/TEE_CreatePersistentObject().
This fixes TA panics while accessing persistent objects:

E/TC:? 0 TA panicked with code 0xffff0001
E/LD:  Status of TA 22250a54-0bf1-48fe-8002-7b20f1c9c9b1
...
D/TC:? 0 user_ta_enter:176 tee_user_ta_enter: TA panicked with
code 0xffff0001

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
