### PR TITLE
[FIO internal] fiovb: add support to delete values

### DIFF
--- a/ta/fiovb/include/ta_fiovb.h
+++ b/ta/fiovb/include/ta_fiovb.h
@@ -26,4 +26,11 @@
  */
 #define TA_FIOVB_CMD_WRITE_PERSIST_VALUE	1
 
+/*
+ * Delete a persistent object corresponding to the given name.
+ *
+ * in	params[0].memref:	persistent value name
+ */
+#define TA_FIOVB_CMD_DELETE_PERSIST_VALUE	2
+
 #endif /*__TA_FIOVB_H*/


### PR DESCRIPTION
Add support to delete values (objects).

Variables (tee objects) are allowed to be created with write, but it is
not currently possible to delete the object completely from tee after
it gets created.

This will also allow vendor specific values to be created as write-only,
which can only be updated if deleted and created from scratch.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>