### PR TITLE
[FIO internal] libnxpse050: route aes_cbc cipher to tomcrypt

### DIFF
--- a/core/lib/libtomcrypt/cbc.c
+++ b/core/lib/libtomcrypt/cbc.c
@@ -120,7 +120,7 @@ static TEE_Result ltc_cbc_alloc_ctx(struct crypto_cipher_ctx **ctx_ret,
 	return TEE_SUCCESS;
 }
 
-#if defined(_CFG_CORE_LTC_AES) && !defined(CFG_CORE_SE05X)
+#if defined(_CFG_CORE_LTC_AES)
 TEE_Result crypto_aes_cbc_alloc_ctx(struct crypto_cipher_ctx **ctx)
 {
 	return ltc_cbc_alloc_ctx(ctx, find_cipher("aes"), false);

--- a/lib/libnxpse050/core/sub.mk
+++ b/lib/libnxpse050/core/sub.mk
@@ -32,7 +32,8 @@ srcs-$(CFG_NXP_SE05X_RNG_DRV) += rng.c
 ifeq ($(CFG_CRYPTO_AES),y)
 # srcs-y += aes.c
 # srcs-$(CFG_CRYPTO_ECB) += aes_ecb.c
-srcs-$(CFG_CRYPTO_CBC) += aes_cbc.c
+# aes cbc cypher slows down RPMB operations, disable
+# srcs-$(CFG_CRYPTO_CBC) += aes_cbc.c
 srcs-$(CFG_CRYPTO_CTR) += aes_ctr.c
 endif
 ifeq ($(CFG_CRYPTO_DES),y)


### PR DESCRIPTION
This symmetrict cipher performance was degrading RPMB access times.
With this change, 1 byte RPMB reads went down from 3 seconds to .07

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
