### PR TITLE
[FIO internal] fiovb: add upgrade_available to persist list

### DIFF
--- a/ta/fiovb/include/ta_fiovb.h
+++ b/ta/fiovb/include/ta_fiovb.h
@@ -8,7 +8,8 @@
 #define TA_FIOVB_UUID {0x22250a54, 0x0bf1, 0x48fe, \
 		      { 0x80, 0x02, 0x7b, 0x20, 0xf1, 0xc9, 0xc9, 0xb1 } }
 
-#define PERSIST_VALUE_LIST {"bootcount", "rollback", "m4hash", "m4size"}
+#define PERSIST_VALUE_LIST {"bootcount", "upgrade_available", "rollback", \
+			    "m4hash", "m4size"}
 
 /*
  * Reads a persistent value corresponding to the given name.


### PR DESCRIPTION
As done by u-boot (via environment), add upgrade_available to the
allowed persist list, so it can be used during the bootflow to avoid
bootcount updates when not really required.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
