### PR TITLE
[FIO fixup] arm: boot: fix support for CFG_OVERLAY_ADDR

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -75,11 +75,11 @@ DECLARE_KEEP_PAGER(sem_cpu_sync);
 #ifdef CFG_DT
 struct dt_descriptor {
 	void *blob;
-#ifdef CFG_EXTERNAL_DTB_OVERLAY
+#if defined(CFG_EXTERNAL_DTB_OVERLAY) || defined(CFG_OVERLAY_ADDR)
 	int frag_id;
+#endif
 #ifdef CFG_OVERLAY_ADDR
 	int is_overlay;
-#endif
 #endif
 };
 


### PR DESCRIPTION
Latest boot code requires frag_id when generating dt fragments, so make
sure it is also exposed when CFG_OVERLAY_ADDR is used, otherwise it
generates a build failure.

To be squashed with "Support overlay at fix address and extend DTS" on a
rebase.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>