### PR TITLE
[FIO extras] MLK-17962-3 core: arm: imx: tune PL310 configuration

### DIFF
--- a/core/arch/arm/include/kernel/tz_ssvce_def.h
+++ b/core/arch/arm/include/kernel/tz_ssvce_def.h
@@ -56,6 +56,7 @@
 #define PL310_LINE_SIZE		32
 #define PL310_8_WAYS		8
 
+#define PL310_CACHE_ID		0x0
 /* reg1 */
 #define PL310_CTRL		0x100
 #define PL310_AUX_CTRL		0x104
@@ -83,6 +84,11 @@
 
 #define PL310_CTRL_ENABLE_BIT	BIT32(0)
 #define PL310_AUX_16WAY_BIT	BIT32(16)
+
+#define PL310_CACHE_ID_PART_MASK	GENMASK_32(9, 6)
+#define PL310_CACHE_ID_PART_L310	(3 << 6)
+#define PL310_CACHE_ID_RTL_MASK		GENMASK_32(5, 0)
+#define PL310_CACHE_ID_RTL_R3P2		0x8
 
 /*
  * SCU iomem

--- a/core/arch/arm/plat-imx/config/imx6sll.h
+++ b/core/arch/arm/plat-imx/config/imx6sll.h
@@ -53,13 +53,13 @@
 /*
  * PL310 Prefetch Control Register
  *
- * Double linefill disabled (bit30=0)
+ * Double linefill enabled (bit30=1)
  * I/D prefetch enabled (bit29:28=2b11)
- * Prefetch drop enabled (bit24=1)
+ * Prefetch drop disabled (bit24=0)
  * Incr double linefill disable (bit23=0)
- * Prefetch offset = 7 (bit4:0)
+ * Prefetch offset = 0xF (bit4:0)
  */
-#define PL310_PREFETCH_CTRL_INIT	0x31000007
+#define PL310_PREFETCH_CTRL_INIT	0x7000000F
 
 /*
  * PL310 Power Register

--- a/core/arch/arm/plat-imx/imx_pl310.c
+++ b/core/arch/arm/plat-imx/imx_pl310.c
@@ -25,13 +25,32 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, PL310_BASE, CORE_MMU_PGDIR_SIZE);
 
 void arm_cl2_config(vaddr_t pl310_base)
 {
+	uint32_t val, cache_id;
+
 	/* Disable PL310 */
 	io_write32(pl310_base + PL310_CTRL, 0);
 
 	io_write32(pl310_base + PL310_TAG_RAM_CTRL, PL310_TAG_RAM_CTRL_INIT);
 	io_write32(pl310_base + PL310_DATA_RAM_CTRL, PL310_DATA_RAM_CTRL_INIT);
 	io_write32(pl310_base + PL310_AUX_CTRL, PL310_AUX_CTRL_INIT);
-	io_write32(pl310_base + PL310_PREFETCH_CTRL, PL310_PREFETCH_CTRL_INIT);
+	/*
+	 * The L2 cache controller(PL310) version on the i.MX6D/Q
+	 * is r3p1-50rel0
+	 * The L2 cache controller(PL310) version on the
+	 * i.MX6DL/SOLO/SL/SX/DQP is r3p2.
+	 * But according to ARM PL310 errata: 752271
+	 * ID: 752271: Double linefill feature can cause data corruption
+	 * Fault Status: Present in: r3p0, r3p1, r3p1-50rel0. Fixed in r3p2
+	 * Workaround: The only workaround to this erratum is to disable the
+	 * double linefill feature. This is the default behavior.
+	 */
+	val = PL310_PREFETCH_CTRL_INIT;
+	cache_id = io_read32(pl310_base + PL310_CACHE_ID);
+	if (((cache_id & PL310_CACHE_ID_PART_MASK) == PL310_CACHE_ID_PART_L310)
+	    && ((cache_id & PL310_CACHE_ID_RTL_MASK) < PL310_CACHE_ID_RTL_R3P2))
+		val &= ~(1 << 30);
+	io_write32(pl310_base + PL310_PREFETCH_CTRL, val);
+
 	io_write32(pl310_base + PL310_POWER_CTRL, PL310_POWER_CTRL_INIT);
 
 	/* invalidate all cache ways */


### PR DESCRIPTION
The current tag/data ram, prefetch value is not the best value.
With this, the performance is not good. So retune the value
to match i.MX design to have good performance.

Also there is PL310 errata that we need to disable Double linefill
for version below r3p2 pl310.

Signed-off-by: Peng Fan <peng.fan@nxp.com>
Signed-off-by: Alessandro Di Chiara <alessandro.dichiara@nxp.com>
Signed-off-by: Michael Scott <mike@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
