### PR TITLE
[FIO internal] Add object name to error output

### DIFF
--- a/ta/fiovb/entry.c
+++ b/ta/fiovb/entry.c
@@ -93,7 +93,7 @@ static TEE_Result write_persist_value(uint32_t pt,
 					 flags, NULL, value,
 					 value_sz, &h);
 	if (res)
-		EMSG("Can't create named object value, res = 0x%x", res);
+		EMSG("Can't create named object '%s' value, res = 0x%x", name_buf, res);
 
 	TEE_CloseObject(h);
 out:
@@ -143,13 +143,13 @@ static TEE_Result read_persist_value(uint32_t pt,
 	res = TEE_OpenPersistentObject(storageid, name_full,
 				       name_full_sz, flags, &h);
 	if (res) {
-		EMSG("Can't open named object value, res = 0x%x", res);
+		EMSG("Can't open named object '%s' value, res = 0x%x", name_buf, res);
 		goto out_free;
 	}
 
 	res =  TEE_ReadObjectData(h, value, value_sz, &count);
 	if (res) {
-		EMSG("Can't read named object value, res = 0x%x", res);
+		EMSG("Can't read named object '%s' value, res = 0x%x", name_buf, res);
 		goto out;
 	}
 


### PR DESCRIPTION
When an RPMB object cannot be created/opened/read the error
only states there was an error, but not what name it was trying
to use. This adds the object name to the error output.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
