### PR TITLE
[FIO internal] Add persist variable m4_update

### DIFF
--- a/ta/fiovb/include/ta_fiovb.h
+++ b/ta/fiovb/include/ta_fiovb.h
@@ -9,7 +9,7 @@
 		      { 0x80, 0x02, 0x7b, 0x20, 0xf1, 0xc9, 0xc9, 0xb1 } }
 
 #define PERSIST_VALUE_LIST {"bootcount", "upgrade_available", "rollback", \
-			    "m4hash", "m4size", "bootupgrade_available", \
+			    "m4hash", "m4size", "m4_update", "bootupgrade_available", \
 			    "bootfirmware_version"}
 
 /*


### PR DESCRIPTION
This adds a persist variable for fiovb for addressing
the case of an m4 update during secondary boot.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
