### PR TITLE
[FIO fromnxp] core: imx: add dynamic shared memory configuration

### DIFF
--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -100,8 +100,14 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC,
 			CORE_MMU_PGDIR_SIZE);
 #endif
 
+#ifdef DRAM0_NSEC_SIZE
+register_dynamic_shm(DRAM0_NSEC_BASE, DRAM0_NSEC_SIZE);
+#else
 register_dynamic_shm(CFG_NSEC_DDR_0_BASE, CFG_NSEC_DDR_0_SIZE);
-#if defined(CFG_NSEC_DDR_1_BASE) && defined(CFG_NSEC_DDR_1_SIZE)
+#endif
+#if defined DRAM1_NSEC_SIZE && ( DRAM1_NSEC_SIZE > 0 )
+register_dynamic_shm(DRAM1_NSEC_BASE, DRAM1_NSEC_SIZE);
+#elif defined(CFG_NSEC_DDR_1_BASE) && defined(CFG_NSEC_DDR_1_SIZE)
 register_dynamic_shm(CFG_NSEC_DDR_1_BASE, CFG_NSEC_DDR_1_SIZE);
 #endif
 

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -69,4 +69,18 @@
 #include <config/imx6sll.h>
 #endif
 
+/*
+ * Calculate Non Secure memory region, after Secure memory carved out.
+ * Assumption is memory for TEE is 32M
+ * Those defines are used to register dynamic shared memory
+ * Currently enable only mscale family.
+ */
+#if defined(CFG_MX8MQ) || defined(CFG_MX8MM) || defined(CFG_MX8MN) ||          \
+	defined(CFG_MX8MP)
+#define DRAM0_NSEC_BASE CFG_DRAM_BASE
+#define DRAM0_NSEC_SIZE (CFG_TZDRAM_START - CFG_DRAM_BASE)
+#define DRAM1_NSEC_BASE (CFG_TZDRAM_START + 0x2000000)
+#define DRAM1_NSEC_SIZE (CFG_DDR_SIZE - DRAM1_NSEC_BASE + CFG_DRAM_BASE)
+#endif
+
 #endif /*PLATFORM_CONFIG_H*/


### PR DESCRIPTION
Add dynamic shared memory configuration and enable it for the iMX
8mscale family.

This is based on the following patches from the NXP BSP tree:
- TEE-517 core: imx: Add dynamic shared memory configuration
- TEE-564 plat-imx: imx8mp enable DDR > 4 Gbytes

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>