### PR TITLE
core: imx: remove HUK stub implementation for iMX8MP

### DIFF
--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -15,7 +15,7 @@
  * lead to using a non secure key.
  */
 #if !defined(CFG_MX6) && !defined(CFG_MX7) && !defined(CFG_MX7ULP) && \
-	!defined(CFG_MX8MM) && !defined(CFG_MX8MQ)
+	!defined(CFG_MX8MM) && !defined(CFG_MX8MQ) && !defined(CFG_MX8MP)
 /*
  * Override these in your platform code to really fetch device-unique
  * bits from e-fuses or whatever.


### PR DESCRIPTION
There's no use case for Foundries where we want this stub implementation
for HUK in most i.MX devices, so don't define this weak function for
i.MX6/7/8M to cause a build break.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
