### PR TITLE
versal: authenc: fix PLM DMA timeout

### DIFF
--- a/core/drivers/crypto/versal/authenc.c
+++ b/core/drivers/crypto/versal/authenc.c
@@ -442,7 +442,7 @@ static TEE_Result update_payload(struct drvcrypt_authenc_update_payload
 
 	input = input_cmd.buf;
 	input->input_addr = virt_to_phys(p.buf);
-	input->input_len = p.len % 4 ? p.alloc_len : p.len;
+	input->input_len = p.len % 16 ? p.alloc_len : p.len;
 	input->is_last = is_last;
 
 	arg.ibuf[0].mem = input_cmd;


### PR DESCRIPTION
Buffer sizes need to be 16 byte aligned or we risk hitting the PLM
AES DMA engine timeout (5 minutes).

This was observed excuting regression 1008.

For future reference debugging was helped with CFG_VERSAL_TRACE_MBOX.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
