### PR TITLE
[FIO toup] crypto: versal: fix memory access after free

### DIFF
--- a/core/drivers/crypto/versal/authenc.c
+++ b/core/drivers/crypto/versal/authenc.c
@@ -616,6 +616,7 @@ static void do_final(void *ctx __unused)
 static void do_free(void *ctx)
 {
 	struct versal_ae_ctx *c = to_versal_ctx(ctx);
+	struct versal_node *next = NULL;
 	struct versal_node *node = NULL;
 
 	if (refcount_dec(&engine.refc)) {
@@ -625,7 +626,7 @@ static void do_free(void *ctx)
 		free(engine.init.nonce.buf);
 		free(engine.init.key.buf);
 		memset(&engine.init, 0, sizeof(engine.init));
-		STAILQ_FOREACH(node, &engine.replay_list, link) {
+		STAILQ_FOREACH_SAFE(node, &engine.replay_list, link, next) {
 			STAILQ_REMOVE(&engine.replay_list, node,
 				      versal_node, link);
 			if (node->is_aad) {


### PR DESCRIPTION
In order to safely release the memory, the _SAFE version of the macro must be used

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
