### PR TITLE
[FIO fromlist] crypto: se050: provision SCP03 keys on SCP03 enablement.

### DIFF
--- a/core/drivers/crypto/se050/adaptors/apis/sss.c
+++ b/core/drivers/crypto/se050/adaptors/apis/sss.c
@@ -152,13 +152,18 @@ sss_status_t se050_enable_scp03(sss_se05x_session_t *session)
 
 		if (!se050_core_early_init(&keys)) {
 			se050_scp03_set_enable(key_src[i]);
-			return kStatus_SSS_Success;
+			goto out;
 		}
 
 		sss_host_session_close(&se050_ctx.host_session);
 	}
 
 	return kStatus_SSS_Fail;
+out:
+	if (IS_ENABLED(CFG_CORE_SE05X_SCP03_PROVISION_ON_INIT))
+		return se050_rotate_scp03_keys(&se050_ctx);
+
+	return kStatus_SSS_Success;
 }
 
 sss_status_t se050_session_open(struct sss_se05x_ctx *ctx,

--- a/core/drivers/crypto/se050/crypto.mk
+++ b/core/drivers/crypto/se050/crypto.mk
@@ -4,7 +4,10 @@ $(call force,CFG_CRYPTO_DRIVER,y)
 CFG_CRYPTO_DRIVER_DEBUG ?= 0
 
 # SE050 initialization
-# Enables the SCP03 key rotation
+# Rotate the SCP03 keys during SCP03 init (does not require user intervention).
+# CAUTION: the provisioning configuration chosen might require a stable HUK.
+CFG_CORE_SE05X_SCP03_PROVISION_ON_INIT ?= n
+# Rotate the SCP03 keys via PTA (request from Normal World).
 CFG_CORE_SE05X_SCP03_PROVISION ?= n
 # Displays the SE050 device information on the console at boot (i.e. OEFID)
 CFG_CORE_SE05X_DISPLAY_INFO ?= y


### PR DESCRIPTION
Rotate the SCP03 keys as soon as the SCP03 communication channel is established.

This can happen during boot or at a later time via normal world request [1].

The rotation configuration that can be built-in in the driver allows the algorithm to rotate to a HUK based secret key or back to the factory based keys.

[1] https://u-boot.readthedocs.io/en/latest/usage/cmd/scp03.html

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
Acked-by: Jerome Forissier <jerome.forissier@linaro.org>
Acked-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
