### PR TITLE
[FIO internal]: : se050: scp03: prohibit derived keys without RPMB ready

### DIFF
--- a/core/drivers/crypto/se050/adaptors/utils/scp_config.c
+++ b/core/drivers/crypto/se050/adaptors/utils/scp_config.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <tee_api_defines_extensions.h>
+#include <tee/tee_fs.h>
 #include <tee/tee_cryp_utl.h>
 #include <utee_defines.h>
 
@@ -417,6 +418,14 @@ static const char *get_scp03_ksrc_name(enum se050_scp03_ksrc ksrc)
 	return NULL;
 }
 
+#ifndef CFG_RPMB_FS
+static bool plat_rpmb_key_is_ready(void)
+{
+	/* without RPMB lets be cautious */
+	return false;
+}
+#endif
+
 sss_status_t se050_scp03_subkey_derive(struct se050_scp_key *keys)
 {
 	struct {
@@ -429,6 +438,10 @@ sss_status_t se050_scp03_subkey_derive(struct se050_scp_key *keys)
 	};
 	uint8_t msg[SE050_SCP03_KEY_SZ + 3] = { 0 };
 	size_t i = 0;
+
+	/* hack: Foundries.io: our platforms are secured when RPMB is ready */
+	if (!plat_rpmb_key_is_ready())
+		return kStatus_SSS_Fail;
 
 	if (IS_ENABLED(CFG_CORE_SCP03_ONLY)) {
 		memset(msg, 0x55, sizeof(msg));


### PR DESCRIPTION
Prevents SCP03 rotation from using the derived keys unless RPMB is available.

This commit must be used particularly when
CFG_CORE_SE05X_SCP03_PROVISION_ON_INIT has been enabled.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
