### PR TITLE
[FIO toup] drivers: se050: disable SM2_* when enabled

### DIFF
--- a/core/drivers/crypto/se050/crypto.mk
+++ b/core/drivers/crypto/se050/crypto.mk
@@ -90,6 +90,10 @@ endif
 # - ECC
 ifeq ($(CFG_NXP_SE05X_ECC_DRV),y)
 $(call force,CFG_CRYPTO_DRV_ECC,y)
+# Disable SM2 as it is not supported by the driver
+$(call force,CFG_CRYPTO_SM2_PKE,n)
+$(call force,CFG_CRYPTO_SM2_KEP,n)
+$(call force,CFG_CRYPTO_SM2_DSA,n)
 endif
 
 # Symmetric ciphers


### PR DESCRIPTION
Not supported by se050, disable following changes done for the CAAM crypto driver.

Proper fix requires software crypto fallback.