### PR TITLE
SM2 fallback

### DIFF
--- a/core/drivers/crypto/caam/acipher/caam_ecc.c
+++ b/core/drivers/crypto/caam/acipher/caam_ecc.c
@@ -142,7 +142,9 @@ static enum caam_ecc_curve get_caam_curve(uint32_t tee_curve)
  * @key        Keypair
  * @size_bits  Key size in bits
  */
-static TEE_Result do_allocate_keypair(struct ecc_keypair *key, size_t size_bits)
+static TEE_Result do_allocate_keypair(struct ecc_keypair *key,
+				      uint32_t type __unused,
+				      size_t size_bits)
 {
 	ECC_TRACE("Allocate Keypair of %zu bits", size_bits);
 
@@ -182,6 +184,7 @@ err:
  * @size_bits  Key size in bits
  */
 static TEE_Result do_allocate_publickey(struct ecc_public_key *key,
+					uint32_t type __unused,
 					size_t size_bits)
 {
 	ECC_TRACE("Allocate Public Key of %zu bits", size_bits);

--- a/core/drivers/crypto/crypto_api/acipher/ecc.c
+++ b/core/drivers/crypto/crypto_api/acipher/ecc.c
@@ -523,7 +523,7 @@ TEE_Result drvcrypt_asym_alloc_ecc_keypair(struct ecc_keypair *key,
 	}
 
 	if (ecc)
-		ret = ecc->alloc_keypair(key, size_bits);
+		ret = ecc->alloc_keypair(key, type, size_bits);
 
 	if (!ret) {
 		key->ops = &ecc_keypair_ops;
@@ -574,7 +574,7 @@ TEE_Result drvcrypt_asym_alloc_ecc_public_key(struct ecc_public_key *key,
 	}
 
 	if (ecc)
-		ret = ecc->alloc_publickey(key, size_bits);
+		ret = ecc->alloc_publickey(key, type, size_bits);
 
 	if (!ret) {
 		key->ops = &ecc_public_key_ops;

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
@@ -149,9 +149,10 @@ struct drvcrypt_ecc_ed {
  */
 struct drvcrypt_ecc {
 	/* Allocates the ECC keypair */
-	TEE_Result (*alloc_keypair)(struct ecc_keypair *key, size_t size_bits);
+	TEE_Result (*alloc_keypair)(struct ecc_keypair *key, uint32_t type,
+				    size_t size_bits);
 	/* Allocates the ECC public key */
-	TEE_Result (*alloc_publickey)(struct ecc_public_key *key,
+	TEE_Result (*alloc_publickey)(struct ecc_public_key *key, uint32_t type,
 				      size_t size_bits);
 	/* Free ECC public key */
 	void (*free_publickey)(struct ecc_public_key *key);

--- a/core/drivers/crypto/se050/core/ecc.c
+++ b/core/drivers/crypto/se050/core/ecc.c
@@ -739,10 +739,14 @@ static TEE_Result do_verify(struct drvcrypt_sign_data *sdata)
 		      sdata->signature.length);
 }
 
-static TEE_Result do_alloc_keypair(struct ecc_keypair *s,
-				   uint32_t type __unused,
+static TEE_Result do_alloc_keypair(struct ecc_keypair *s, uint32_t type,
 				   size_t size_bits __unused)
 {
+	/* This driver only supports ECDH/ECDSA */
+	if (type != TEE_TYPE_ECDSA_KEYPAIR &&
+	    type != TEE_TYPE_ECDH_KEYPAIR)
+		return TEE_ERROR_NOT_IMPLEMENTED;
+
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->d))
 		goto err;
@@ -758,11 +762,14 @@ err:
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
-static TEE_Result do_alloc_publickey(struct ecc_public_key *s,
-				     uint32_t type __unused,
+static TEE_Result do_alloc_publickey(struct ecc_public_key *s, uint32_t type,
 				     size_t size_bits __unused)
-
 {
+	/* This driver only supports ECDH/ECDSA */
+	if (type != TEE_TYPE_ECDSA_PUBLIC_KEY &&
+	    type != TEE_TYPE_ECDH_PUBLIC_KEY)
+		return TEE_ERROR_NOT_IMPLEMENTED;
+
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->x))
 		goto err;
@@ -803,6 +810,12 @@ static TEE_Result ecc_init(void)
 	pair_ops = crypto_asym_get_ecc_keypair_ops(TEE_TYPE_ECDSA_KEYPAIR);
 	if (!pair_ops)
 		return TEE_ERROR_GENERIC;
+
+	/* This driver supports both ECDH and ECDSA */
+	assert((pub_ops ==
+		crypto_asym_get_ecc_public_ops(TEE_TYPE_ECDH_PUBLIC_KEY)) &&
+	       (pair_ops ==
+		crypto_asym_get_ecc_keypair_ops(TEE_TYPE_ECDH_KEYPAIR)));
 
 	return drvcrypt_register_ecc(&driver_ecc);
 }

--- a/core/drivers/crypto/se050/core/ecc.c
+++ b/core/drivers/crypto/se050/core/ecc.c
@@ -740,6 +740,7 @@ static TEE_Result do_verify(struct drvcrypt_sign_data *sdata)
 }
 
 static TEE_Result do_alloc_keypair(struct ecc_keypair *s,
+				   uint32_t type __unused,
 				   size_t size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
@@ -758,7 +759,9 @@ err:
 }
 
 static TEE_Result do_alloc_publickey(struct ecc_public_key *s,
+				     uint32_t type __unused,
 				     size_t size_bits __unused)
+
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->x))

--- a/core/drivers/crypto/se050/crypto.mk
+++ b/core/drivers/crypto/se050/crypto.mk
@@ -90,10 +90,6 @@ endif
 # - ECC
 ifeq ($(CFG_NXP_SE05X_ECC_DRV),y)
 $(call force,CFG_CRYPTO_DRV_ECC,y)
-# Disable SM2 as it is not supported by the driver
-$(call force,CFG_CRYPTO_SM2_PKE,n)
-$(call force,CFG_CRYPTO_SM2_KEP,n)
-$(call force,CFG_CRYPTO_SM2_DSA,n)
 endif
 
 # Symmetric ciphers

--- a/core/drivers/crypto/versal/ecc.c
+++ b/core/drivers/crypto/versal/ecc.c
@@ -366,7 +366,9 @@ static TEE_Result do_gen_keypair(struct ecc_keypair *s, size_t size_bits)
 	return keypair_ops->generate(s, size_bits);
 }
 
-static TEE_Result do_alloc_keypair(struct ecc_keypair *s, size_t size_bits)
+static TEE_Result do_alloc_keypair(struct ecc_keypair *s,
+				   uint32_t type __unused,
+				   size_t size_bits)
 {
 	TEE_Result ret = TEE_SUCCESS;
 
@@ -380,7 +382,9 @@ static TEE_Result do_alloc_keypair(struct ecc_keypair *s, size_t size_bits)
 	return TEE_SUCCESS;
 }
 
-static TEE_Result do_alloc_publickey(struct ecc_public_key *s, size_t size_bits)
+static TEE_Result do_alloc_publickey(struct ecc_public_key *s,
+				     uint32_t type __unused,
+				     size_t size_bits)
 {
 	TEE_Result ret = TEE_SUCCESS;
 


### PR DESCRIPTION
This PR reverts the patch that disables ECC SM2_ support when the SE050 is enabled.

I implemented software fallback for the unsupported ECC algorithms in the SE050 crypto driver back in OPTEE_OS 3.22.0. 

So Instead of disabling SM2 support, lets just backport those patches.


Tested-by: Jorge Ramirez-Ortiz <jorge@foundries.io>