### PR TITLE
[FIO fromtree] drivers: se050: fix default configuration for the SE a…

### DIFF
--- a/core/drivers/crypto/se050/crypto.mk
+++ b/core/drivers/crypto/se050/crypto.mk
@@ -29,7 +29,7 @@ CFG_CORE_SE05X_INIT_NVM ?= n
 # confirmation from the SE that the NVM object has been removed.
 CFG_CORE_SE05X_BLOCK_OBJ_DEL_ON_ERROR ?= n
 # Select the SE05X applet version for aligning the built-in features
-+CFG_CORE_SE05X_VER ?= 03_XX
+CFG_CORE_SE05X_VER ?= 03_XX
 
 # I2C bus baudrate (depends on SoC)
 CFG_CORE_SE05X_BAUDRATE ?= 3400000


### PR DESCRIPTION
…pplet

Invalid character was merged in the fixed commit.

Fixes: fb559031c25f ("drivers: se050: allow configuring the Secure Element applet")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
