### PR TITLE
SE050F ECC keypair generation and shared secret fix

### DIFF
--- a/core/drivers/crypto/se050/core/ecc.c
+++ b/core/drivers/crypto/se050/core/ecc.c
@@ -439,7 +439,9 @@ static TEE_Result shared_secret(struct ecc_keypair *private_key,
 	if (private_key->curve != public_key->curve)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	ret = ecc_get_key_size(private_key->curve, 0, &key_bytes, &key_bits);
+	ret = ecc_get_key_size(private_key->curve,
+			       TEE_ALG_ECDH_DERIVE_SHARED_SECRET,
+			       &key_bytes, &key_bits);
 	if (ret) {
 		if (ret != TEE_ERROR_NOT_IMPLEMENTED)
 			return ret;

--- a/core/drivers/crypto/se050/core/ecc.c
+++ b/core/drivers/crypto/se050/core/ecc.c
@@ -36,6 +36,9 @@ static bool oefid_key_supported(size_t bits)
 
 static bool oefid_algo_supported(uint32_t algo)
 {
+	if (!algo)
+		return true;
+
 	switch (se050_get_oefid()) {
 	case SE050F_ID:
 		switch (algo) {


### PR DESCRIPTION
Fix ECC part for SE050 in F configuration:
- revert commit db8ca286ea44786a19e344ca02b47cc8be04924e to have working keypair generation
- fix shared secret generation in another way, passing the ECDH algo (the only one used) to ecc_get_key_size() 
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
